### PR TITLE
feat: v3.0.0 multi-targeting, immutable errors refactor, and repo rebrand

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,11 +2,13 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
 end_of_line = crlf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.cs]
+indent_size = 4
 
 # SA1615: Element return value should be documented.
 dotnet_diagnostic.SA1615.severity = none

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Setup .NET
               uses: actions/setup-dotnet@v1
               with:
-                  dotnet-version: 9.0.x
+                  dotnet-version: 10.0.x
             - name: Restore dependencies
               run: dotnet restore
             - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Setup dotnet
               uses: actions/setup-dotnet@v1
               with:
-                  dotnet-version: 9.0.x
+                  dotnet-version: 10.0.x
 
             # Publish
             - name: Package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ All notable changes to this project are documented in this file.
 ### Changed
 
 - Internals of `ErrorOr<TValue>` were refactored to use `ImmutableArray<Error>` instead of `List<Error>` for better immutability and performance. All public APIs that expose or accept collections of errors now use `ImmutableArray<Error>`.
-- `ErrorOr<TValue>.FirstError` now returns `Error?` to avoid ambiguous default values when no errors are present.
 - Implicit conversion from `Error` to `ErrorOr<TValue>` now wraps the single error into a non-empty errors collection, ensuring consistent `Errors` behavior.
 - Equality and hash code implementations were updated to use sequence equality for the underlying immutable error collection.
 - Tests were updated and aligned with the new error representation and target frameworks.
@@ -22,7 +21,6 @@ All notable changes to this project are documented in this file.
 
 - All APIs that previously accepted or returned `List<Error>` now use `ImmutableArray<Error>`. Call sites relying on the previous collection types may require adjustments.
 - Public constructors of `ErrorOr<TValue>` were made `internal`. Creating instances should now be done via `ErrorOrFactory`, `ToErrorOr`, or implicit conversions.
-- `FirstError` for successful results now returns `null` instead of a default `Error` instance, so code that assumes a non-null value must be updated to handle the nullable return type.
 - For successful results, the `Errors` collection no longer contains a special "no error" sentinel item. It is now an empty collection. Code that relied on this sentinel (for example, by assuming `Errors` is always non-empty and contains a "no error" value for success) must be updated to treat an empty `Errors` as the indicator of success.
 
 ## [1.10.0] - 2024-02-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project are documented in this file.
 
+## [3.0.0] - 2025-12-04
+
+### Added
+
+- Support for .NET 9.0 and .NET 10.0 – the library now multi-targets `net8.0`, `net9.0`, and `net10.0`.
+- Updated CI workflows to build, test, and publish using .NET 10.0.x.
+
+### Changed
+
+- Internals of `ErrorOr<TValue>` were refactored to use `ImmutableArray<Error>` instead of `List<Error>` for better immutability and performance. All public APIs that expose or accept collections of errors now use `ImmutableArray<Error>`.
+- `ErrorOr<TValue>.FirstError` now returns `Error?` to avoid ambiguous default values when no errors are present.
+- Implicit conversion from `Error` to `ErrorOr<TValue>` now wraps the single error into a non-empty errors collection, ensuring consistent `Errors` behavior.
+- Equality and hash code implementations were updated to use sequence equality for the underlying immutable error collection.
+- Tests were updated and aligned with the new error representation and target frameworks.
+- README and badges were refreshed to point to the new repository and CI setup.
+
+### Breaking Changes
+
+- All APIs that previously accepted or returned `List<Error>` now use `ImmutableArray<Error>`. Call sites relying on the previous collection types may require adjustments.
+- Public constructors of `ErrorOr<TValue>` were made `internal`. Creating instances should now be done via `ErrorOrFactory`, `ToErrorOr`, or implicit conversions.
+- `FirstError` for successful results now returns `null` instead of a default `Error` instance, so code that assumes a non-null value must be updated to handle the nullable return type.
+- For successful results, the `Errors` collection no longer contains a special "no error" sentinel item. It is now an empty collection. Code that relied on this sentinel (for example, by assuming `Errors` is always non-empty and contains a "no error" value for success) must be updated to treat an empty `Errors` as the indicator of success.
+
 ## [1.10.0] - 2024-02-14
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -12,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/ErrorOr.slnx
+++ b/ErrorOr.slnx
@@ -1,4 +1,12 @@
 <Solution>
+  <Folder Name="/Solution Items/">
+    <File Path=".editorconfig" />
+    <File Path=".gitignore" />
+    <File Path="CHANGELOG.md" />
+    <File Path="Directory.Build.props" />
+    <File Path="LICENSE.md" />
+    <File Path="README.md" />
+  </Folder>
   <Project Path="src/ErrorOr.csproj" />
   <Project Path="tests/Tests.csproj" />
 </Solution>

--- a/ErrorOr.slnx
+++ b/ErrorOr.slnx
@@ -1,6 +1,8 @@
 <Solution>
   <Folder Name="/Solution Items/">
     <File Path=".editorconfig" />
+    <File Path=".github/workflows/build.yml" />
+    <File Path=".github/workflows/publish.yml" />
     <File Path=".gitignore" />
     <File Path="CHANGELOG.md" />
     <File Path="Directory.Build.props" />

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="assets/icon.png" alt="drawing" width="700px"/></br>
 
-[![NuGet](https://img.shields.io/nuget/v/erroror.svg)](https://www.nuget.org/packages/erroror)
+[![NuGet](https://img.shields.io/nuget/v/dzhukovsky.erroror.svg)](https://www.nuget.org/packages/dzhukovsky.erroror)
 
 [![Build](https://github.com/dzhukovsky/error-or/actions/workflows/build.yml/badge.svg)](https://github.com/dzhukovsky/error-or/actions/workflows/build.yml) [![publish ErrorOr to nuget](https://github.com/dzhukovsky/error-or/actions/workflows/publish.yml/badge.svg)](https://github.com/dzhukovsky/error-or/actions/workflows/publish.yml)
 
@@ -13,7 +13,7 @@
 
 ### A simple, fluent discriminated union of an error or a result.
 
-`dotnet add package ErrorOr`
+`dotnet add package dzhukovsky.ЕrrorОr`
 
 </div>
 
@@ -327,6 +327,8 @@ if (!result.IsError) // the result contains a value
 
 ## `Errors`
 
+The `Errors` property returns the collection of errors. For successful results, this collection is empty.
+
 ```cs
 ErrorOr<int> result = User.Create();
 
@@ -338,6 +340,8 @@ if (result.IsError)
 ```
 
 ## `FirstError`
+
+The `FirstError` property returns `Error?`. For a successful result, it is `null`. For an error result, it returns the first error that occurred.
 
 ```cs
 ErrorOr<int> result = User.Create();
@@ -744,6 +748,7 @@ If you have any questions, comments, or suggestions, please open an issue or cre
 
 # Credits 🙏
 
+-   [amantinband/error-or](https://github.com/amantinband/error-or) - This repository is an extended fork of the original ErrorOr library
 -   [OneOf](https://github.com/mcintyre321/OneOf/tree/master/OneOf) - An awesome library which provides F# style discriminated unions behavior for C#
 
 # License 🪪

--- a/README.md
+++ b/README.md
@@ -341,8 +341,6 @@ if (result.IsError)
 
 ## `FirstError`
 
-The `FirstError` property returns `Error?`. For a successful result, it is `null`. For an error result, it returns the first error that occurred.
-
 ```cs
 ErrorOr<int> result = User.Create();
 

--- a/src/ErrorOr.csproj
+++ b/src/ErrorOr.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>dzhukovsky.ErrorOr</PackageId>
-    <Version>3.0.0-alpha.2</Version>
+    <Version>3.0.0</Version>
     <Authors>Dmitry Zhukovsky</Authors>
     <PackageIcon>icon-square.png</PackageIcon>
     <PackageTags>Result,Results,ErrorOr,Error,Handling</PackageTags>

--- a/src/ErrorOr.csproj
+++ b/src/ErrorOr.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>dzhukovsky.ErrorOr</PackageId>
-    <Version>3.0.0-alpha.1</Version>
+    <Version>3.0.0-alpha.2</Version>
     <Authors>Dmitry Zhukovsky</Authors>
     <PackageIcon>icon-square.png</PackageIcon>
     <PackageTags>Result,Results,ErrorOr,Error,Handling</PackageTags>

--- a/src/ErrorOr.csproj
+++ b/src/ErrorOr.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/ErrorOr/ErrorOr.Else.cs
+++ b/src/ErrorOr/ErrorOr.Else.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace ErrorOr;
 
 public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
@@ -7,7 +9,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public ErrorOr<TValue> Else(Func<IReadOnlyList<Error>, Error> onError)
+    public ErrorOr<TValue> Else(Func<ImmutableArray<Error>, Error> onError)
     {
         if (!IsError)
         {
@@ -22,7 +24,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public ErrorOr<TValue> Else(Func<IReadOnlyList<Error>, IReadOnlyList<Error>> onError)
+    public ErrorOr<TValue> Else(Func<ImmutableArray<Error>, ImmutableArray<Error>> onError)
     {
         if (!IsError)
         {
@@ -52,7 +54,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public ErrorOr<TValue> Else(Func<IReadOnlyList<Error>, TValue> onError)
+    public ErrorOr<TValue> Else(Func<ImmutableArray<Error>, TValue> onError)
     {
         if (!IsError)
         {
@@ -82,7 +84,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public async Task<ErrorOr<TValue>> ElseAsync(Func<IReadOnlyList<Error>, Task<TValue>> onError)
+    public async Task<ErrorOr<TValue>> ElseAsync(Func<ImmutableArray<Error>, Task<TValue>> onError)
     {
         if (!IsError)
         {
@@ -97,7 +99,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public async Task<ErrorOr<TValue>> ElseAsync(Func<IReadOnlyList<Error>, Task<Error>> onError)
+    public async Task<ErrorOr<TValue>> ElseAsync(Func<ImmutableArray<Error>, Task<Error>> onError)
     {
         if (!IsError)
         {
@@ -112,7 +114,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
-    public async Task<ErrorOr<TValue>> ElseAsync(Func<IReadOnlyList<Error>, Task<IReadOnlyList<Error>>> onError)
+    public async Task<ErrorOr<TValue>> ElseAsync(Func<ImmutableArray<Error>, Task<ImmutableArray<Error>>> onError)
     {
         if (!IsError)
         {

--- a/src/ErrorOr/ErrorOr.ElseExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ElseExtensions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace ErrorOr;
 
 public static partial class ErrorOrExtensions
@@ -9,7 +11,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<IReadOnlyList<Error>, TValue> onError)
+    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ImmutableArray<Error>, TValue> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -37,7 +39,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<IReadOnlyList<Error>, Task<TValue>> onError)
+    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ImmutableArray<Error>, Task<TValue>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -65,7 +67,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<IReadOnlyList<Error>, Error> onError)
+    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ImmutableArray<Error>, Error> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -79,7 +81,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<IReadOnlyList<Error>, IReadOnlyList<Error>> onError)
+    public static async Task<ErrorOr<TValue>> Else<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ImmutableArray<Error>, ImmutableArray<Error>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -107,7 +109,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<IReadOnlyList<Error>, Task<Error>> onError)
+    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ImmutableArray<Error>, Task<Error>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -121,7 +123,7 @@ public static partial class ErrorOrExtensions
     /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
     /// <param name="onError">The function to execute if the state is error.</param>
     /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original value.</returns>
-    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<IReadOnlyList<Error>, Task<IReadOnlyList<Error>>> onError)
+    public static async Task<ErrorOr<TValue>> ElseAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<ImmutableArray<Error>, Task<ImmutableArray<Error>>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 

--- a/src/ErrorOr/ErrorOr.Equality.cs
+++ b/src/ErrorOr/ErrorOr.Equality.cs
@@ -1,5 +1,3 @@
-using System.Collections.Immutable;
-
 namespace ErrorOr;
 
 public readonly partial record struct ErrorOr<TValue>
@@ -11,7 +9,7 @@ public readonly partial record struct ErrorOr<TValue>
             return !other.IsError && EqualityComparer<TValue>.Default.Equals(Value, other.Value);
         }
 
-        return other.IsError && CheckIfErrorsAreEqual(Errors, other.Errors);
+        return other.IsError && Errors.SequenceEqual(other.Errors);
     }
 
     public override int GetHashCode()
@@ -30,33 +28,5 @@ public readonly partial record struct ErrorOr<TValue>
         }
 
         return hashCode.ToHashCode();
-    }
-
-    private static bool CheckIfErrorsAreEqual(ImmutableArray<Error> errors1, ImmutableArray<Error> errors2)
-    {
-        // This method is currently implemented with strict ordering in mind, so the errors
-        // of the two lists need to be in the exact same order.
-        // This avoids allocating a hash set. We could provide a dedicated EqualityComparer for
-        // ErrorOr<TValue> when arbitrary orders should be supported.
-
-        // TODO: Revisit whether this reference check is beneficial
-        // if (ReferenceEquals(errors1, errors2))
-        // {
-        //     return true;
-        // }
-        if (errors1.Length != errors2.Length)
-        {
-            return false;
-        }
-
-        for (var i = 0; i < errors1.Length; i++)
-        {
-            if (!errors1[i].Equals(errors2[i]))
-            {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/src/ErrorOr/ErrorOr.Equality.cs
+++ b/src/ErrorOr/ErrorOr.Equality.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace ErrorOr;
 
 public readonly partial record struct ErrorOr<TValue>
@@ -22,7 +24,7 @@ public readonly partial record struct ErrorOr<TValue>
 #pragma warning disable SA1129 // HashCode needs to be instantiated this way
         var hashCode = new HashCode();
 #pragma warning restore SA1129
-        for (var i = 0; i < Errors.Count; i++)
+        for (var i = 0; i < Errors.Length; i++)
         {
             hashCode.Add(Errors[i]);
         }
@@ -30,23 +32,24 @@ public readonly partial record struct ErrorOr<TValue>
         return hashCode.ToHashCode();
     }
 
-    private static bool CheckIfErrorsAreEqual(IReadOnlyList<Error> errors1, IReadOnlyList<Error> errors2)
+    private static bool CheckIfErrorsAreEqual(ImmutableArray<Error> errors1, ImmutableArray<Error> errors2)
     {
         // This method is currently implemented with strict ordering in mind, so the errors
         // of the two lists need to be in the exact same order.
         // This avoids allocating a hash set. We could provide a dedicated EqualityComparer for
         // ErrorOr<TValue> when arbitrary orders should be supported.
-        if (ReferenceEquals(errors1, errors2))
-        {
-            return true;
-        }
 
-        if (errors1.Count != errors2.Count)
+        // TODO: Revisit whether this reference check is beneficial
+        // if (ReferenceEquals(errors1, errors2))
+        // {
+        //     return true;
+        // }
+        if (errors1.Length != errors2.Length)
         {
             return false;
         }
 
-        for (var i = 0; i < errors1.Count; i++)
+        for (var i = 0; i < errors1.Length; i++)
         {
             if (!errors1[i].Equals(errors2[i]))
             {

--- a/src/ErrorOr/ErrorOr.ImplicitConverters.cs
+++ b/src/ErrorOr/ErrorOr.ImplicitConverters.cs
@@ -8,7 +8,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     public static implicit operator ErrorOr<TValue>(TValue value) => new(value);
 
     /// <summary>Creates an <see cref="ErrorOr{TValue}"/> from an error.</summary>
-    public static implicit operator ErrorOr<TValue>(Error error) => new(error);
+    public static implicit operator ErrorOr<TValue>(Error error) => new([error]);
 
     /// <summary>Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.</summary>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>

--- a/src/ErrorOr/ErrorOr.ImplicitConverters.cs
+++ b/src/ErrorOr/ErrorOr.ImplicitConverters.cs
@@ -1,45 +1,30 @@
+using System.Collections.Immutable;
+
 namespace ErrorOr;
 
 public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
 {
-    /// <summary>
-    /// Creates an <see cref="ErrorOr{TValue}"/> from a value.
-    /// </summary>
-    public static implicit operator ErrorOr<TValue>(TValue value)
-    {
-        return new ErrorOr<TValue>(value);
-    }
+    /// <summary>Creates an <see cref="ErrorOr{TValue}"/> from a value.</summary>
+    public static implicit operator ErrorOr<TValue>(TValue value) => new(value);
 
-    /// <summary>
-    /// Creates an <see cref="ErrorOr{TValue}"/> from an error.
-    /// </summary>
-    public static implicit operator ErrorOr<TValue>(Error error)
-    {
-        return new ErrorOr<TValue>(error);
-    }
+    /// <summary>Creates an <see cref="ErrorOr{TValue}"/> from an error.</summary>
+    public static implicit operator ErrorOr<TValue>(Error error) => new(error);
 
-    /// <summary>
-    /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
-    /// </summary>
+    /// <summary>Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.</summary>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty list.</exception>
-    public static implicit operator ErrorOr<TValue>(List<Error> errors)
-    {
-        return new ErrorOr<TValue>(errors);
-    }
+    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty array.</exception>
+    public static implicit operator ErrorOr<TValue>(ImmutableArray<Error> errors)
+        => ErrorOrFactory.Create<TValue>(errors);
 
-    /// <summary>
-    /// Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.
-    /// </summary>
+    /// <summary>Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.</summary>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty array.</exception>
     public static implicit operator ErrorOr<TValue>(Error[] errors)
-    {
-        if (errors is null)
-        {
-            throw new ArgumentNullException(nameof(errors));
-        }
+        => ErrorOrFactory.Create<TValue>(errors);
 
-        return new ErrorOr<TValue>([.. errors]);
-    }
+    /// <summary>Creates an <see cref="ErrorOr{TValue}"/> from a list of errors.</summary>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty array.</exception>
+    public static implicit operator ErrorOr<TValue>(List<Error> errors)
+        => ErrorOrFactory.Create<TValue>(errors);
 }

--- a/src/ErrorOr/ErrorOr.Match.cs
+++ b/src/ErrorOr/ErrorOr.Match.cs
@@ -55,7 +55,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     {
         if (IsError)
         {
-            return onFirstError(FirstError.Value);
+            return onFirstError(FirstError);
         }
 
         return onValue(Value);
@@ -74,7 +74,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     {
         if (IsError)
         {
-            return await onFirstError(FirstError.Value).ConfigureAwait(false);
+            return await onFirstError(FirstError).ConfigureAwait(false);
         }
 
         return await onValue(Value).ConfigureAwait(false);

--- a/src/ErrorOr/ErrorOr.Match.cs
+++ b/src/ErrorOr/ErrorOr.Match.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace ErrorOr;
 
 public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
@@ -11,7 +13,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <param name="onValue">The function to execute if the state is a value.</param>
     /// <param name="onError">The function to execute if the state is an error.</param>
     /// <returns>The result of the executed function.</returns>
-    public TNextValue Match<TNextValue>(Func<TValue, TNextValue> onValue, Func<IReadOnlyList<Error>, TNextValue> onError)
+    public TNextValue Match<TNextValue>(Func<TValue, TNextValue> onValue, Func<ImmutableArray<Error>, TNextValue> onError)
     {
         if (IsError)
         {
@@ -30,7 +32,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <param name="onValue">The asynchronous function to execute if the state is a value.</param>
     /// <param name="onError">The asynchronous function to execute if the state is an error.</param>
     /// <returns>A task representing the asynchronous operation that yields the result of the executed function.</returns>
-    public async Task<TNextValue> MatchAsync<TNextValue>(Func<TValue, Task<TNextValue>> onValue, Func<IReadOnlyList<Error>, Task<TNextValue>> onError)
+    public async Task<TNextValue> MatchAsync<TNextValue>(Func<TValue, Task<TNextValue>> onValue, Func<ImmutableArray<Error>, Task<TNextValue>> onError)
     {
         if (IsError)
         {
@@ -53,7 +55,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     {
         if (IsError)
         {
-            return onFirstError(FirstError);
+            return onFirstError(FirstError.Value);
         }
 
         return onValue(Value);
@@ -72,7 +74,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     {
         if (IsError)
         {
-            return await onFirstError(FirstError).ConfigureAwait(false);
+            return await onFirstError(FirstError.Value).ConfigureAwait(false);
         }
 
         return await onValue(Value).ConfigureAwait(false);

--- a/src/ErrorOr/ErrorOr.MatchExtensions.cs
+++ b/src/ErrorOr/ErrorOr.MatchExtensions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace ErrorOr;
 
 public static partial class ErrorOrExtensions
@@ -13,7 +15,7 @@ public static partial class ErrorOrExtensions
     /// <param name="onValue">The function to execute if the state is a value.</param>
     /// <param name="onError">The function to execute if the state is an error.</param>
     /// <returns>The result of the executed function.</returns>
-    public static async Task<TNextValue> Match<TValue, TNextValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, TNextValue> onValue, Func<IReadOnlyList<Error>, TNextValue> onError)
+    public static async Task<TNextValue> Match<TValue, TNextValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, TNextValue> onValue, Func<ImmutableArray<Error>, TNextValue> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -31,7 +33,7 @@ public static partial class ErrorOrExtensions
     /// <param name="onValue">The function to execute if the state is a value.</param>
     /// <param name="onError">The function to execute if the state is an error.</param>
     /// <returns>The result of the executed function.</returns>
-    public static async Task<TNextValue> MatchAsync<TValue, TNextValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task<TNextValue>> onValue, Func<IReadOnlyList<Error>, Task<TNextValue>> onError)
+    public static async Task<TNextValue> MatchAsync<TValue, TNextValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task<TNextValue>> onValue, Func<ImmutableArray<Error>, Task<TNextValue>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 

--- a/src/ErrorOr/ErrorOr.Switch.cs
+++ b/src/ErrorOr/ErrorOr.Switch.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace ErrorOr;
 
 public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
@@ -9,7 +11,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// </summary>
     /// <param name="onValue">The action to execute if the state is a value.</param>
     /// <param name="onError">The action to execute if the state is an error.</param>
-    public void Switch(Action<TValue> onValue, Action<IReadOnlyList<Error>> onError)
+    public void Switch(Action<TValue> onValue, Action<ImmutableArray<Error>> onError)
     {
         if (IsError)
         {
@@ -28,7 +30,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <param name="onValue">The asynchronous action to execute if the state is a value.</param>
     /// <param name="onError">The asynchronous action to execute if the state is an error.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public async Task SwitchAsync(Func<TValue, Task> onValue, Func<IReadOnlyList<Error>, Task> onError)
+    public async Task SwitchAsync(Func<TValue, Task> onValue, Func<ImmutableArray<Error>, Task> onError)
     {
         if (IsError)
         {
@@ -50,7 +52,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     {
         if (IsError)
         {
-            onFirstError(FirstError);
+            onFirstError(FirstError.Value);
             return;
         }
 
@@ -69,7 +71,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     {
         if (IsError)
         {
-            await onFirstError(FirstError).ConfigureAwait(false);
+            await onFirstError(FirstError.Value).ConfigureAwait(false);
             return;
         }
 

--- a/src/ErrorOr/ErrorOr.Switch.cs
+++ b/src/ErrorOr/ErrorOr.Switch.cs
@@ -52,7 +52,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     {
         if (IsError)
         {
-            onFirstError(FirstError.Value);
+            onFirstError(FirstError);
             return;
         }
 
@@ -71,7 +71,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     {
         if (IsError)
         {
-            await onFirstError(FirstError.Value).ConfigureAwait(false);
+            await onFirstError(FirstError).ConfigureAwait(false);
             return;
         }
 

--- a/src/ErrorOr/ErrorOr.SwitchExtensions.cs
+++ b/src/ErrorOr/ErrorOr.SwitchExtensions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace ErrorOr;
 
 public static partial class ErrorOrExtensions
@@ -12,7 +14,7 @@ public static partial class ErrorOrExtensions
     /// <param name="onValue">The action to execute if the state is a value.</param>
     /// <param name="onError">The action to execute if the state is an error.</param>
     /// <returns>The result of the executed function.</returns>
-    public static async Task Switch<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> onValue, Action<IReadOnlyList<Error>> onError)
+    public static async Task Switch<TValue>(this Task<ErrorOr<TValue>> errorOr, Action<TValue> onValue, Action<ImmutableArray<Error>> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 
@@ -29,7 +31,7 @@ public static partial class ErrorOrExtensions
     /// <param name="onValue">The action to execute if the state is a value.</param>
     /// <param name="onError">The action to execute if the state is an error.</param>
     /// <returns>The result of the executed function.</returns>
-    public static async Task SwitchAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> onValue, Func<IReadOnlyList<Error>, Task> onError)
+    public static async Task SwitchAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> onValue, Func<ImmutableArray<Error>, Task> onError)
     {
         var result = await errorOr.ConfigureAwait(false);
 

--- a/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace ErrorOr;
 
 public static partial class ErrorOrExtensions
@@ -5,36 +7,31 @@ public static partial class ErrorOrExtensions
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="value"/>.
     /// </summary>
-    public static ErrorOr<TValue> ToErrorOr<TValue>(this TValue value)
-    {
-        return value;
-    }
+    public static ErrorOr<TValue> ToErrorOr<TValue>(this TValue value) => value;
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="error"/>.
     /// </summary>
-    public static ErrorOr<TValue> ToErrorOr<TValue>(this Error error)
-    {
-        return error;
-    }
+    public static ErrorOr<TValue> ToErrorOr<TValue>(this Error error) => error;
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="errors"/>.
     /// </summary>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty list.</exception>
-    public static ErrorOr<TValue> ToErrorOr<TValue>(this IReadOnlyList<Error> errors)
-    {
-        return ErrorOr<TValue>.From(errors);
-    }
+    public static ErrorOr<TValue> ToErrorOr<TValue>(this ImmutableArray<Error> errors) => errors;
 
     /// <summary>
     /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="errors"/>.
     /// </summary>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty array.</exception>
-    public static ErrorOr<TValue> ToErrorOr<TValue>(this Error[] errors)
-    {
-        return errors;
-    }
+    public static ErrorOr<TValue> ToErrorOr<TValue>(this Error[] errors) => errors;
+
+    /// <summary>
+    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="errors"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty list.</exception>
+    public static ErrorOr<TValue> ToErrorOr<TValue>(this List<Error> errors) => errors;
 }

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -39,10 +39,9 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     public ImmutableArray<Error> Errors { get; }
 
     /// <summary>Gets the first error or the default value.</summary>
-    public Error? FirstError => IsError ? Errors[0] : null;
+    public Error FirstError => IsError ? Errors[0] : default;
 
     /// <summary>Gets a value indicating whether the result contains errors.</summary>
-    [MemberNotNullWhen(true, nameof(FirstError))]
     [MemberNotNullWhen(false, nameof(Value))]
     public bool IsError => Errors.Length > 0;
 

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -16,7 +16,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
 
     /// <summary>Create an error result from the specified non-empty error list.</summary>
     /// <exception cref="ArgumentException">List is empty.</exception>
-    public ErrorOr(params ImmutableArray<Error> errors)
+    internal ErrorOr(ImmutableArray<Error> errors)
     {
         if (errors.Length == 0)
         {
@@ -27,7 +27,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     }
 
     /// <summary>Create a successful result from the specified value.</summary>
-    public ErrorOr(TValue value)
+    internal ErrorOr(TValue value)
     {
         ArgumentNullException.ThrowIfNull(value);
 

--- a/src/ErrorOr/ErrorOrFactory.cs
+++ b/src/ErrorOr/ErrorOrFactory.cs
@@ -1,18 +1,23 @@
+using System.Collections.Immutable;
+
 namespace ErrorOr;
 
-/// <summary>
-/// Provides factory methods for creating instances of <see cref="ErrorOr{TValue}"/>.
-/// </summary>
+/// <summary>Provides factory methods for creating instances of <see cref="ErrorOr{TValue}"/>.</summary>
 public static class ErrorOrFactory
 {
-    /// <summary>
-    /// Creates a new instance of <see cref="ErrorOr{TValue}"/> with a value.
-    /// </summary>
-    /// <typeparam name="TValue">The type of the value.</typeparam>
-    /// <param name="value">The value to wrap.</param>
-    /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing the provided value.</returns>
-    public static ErrorOr<TValue> From<TValue>(TValue value)
+    /// <summary>Create a successful result from the specified value.</summary>
+    public static ErrorOr<TValue> Create<TValue>(TValue value) => new(value);
+
+    /// <summary>Create an error result from the specified non-empty error list.</summary>
+    /// <exception cref="ArgumentException">List is empty.</exception>
+    public static ErrorOr<TValue> Create<TValue>(ImmutableArray<Error> errors) => new(errors);
+
+    /// <summary>Create an error result from the specified non-empty error list.</summary>
+    /// <exception cref="ArgumentNullException">List is null.</exception>
+    /// <exception cref="ArgumentException">List is empty.</exception>
+    public static ErrorOr<TValue> Create<TValue>(IReadOnlyList<Error> errors)
     {
-        return value;
+        ArgumentNullException.ThrowIfNull(errors);
+        return new([.. errors]);
     }
 }

--- a/src/ErrorOr/IErrorOr.cs
+++ b/src/ErrorOr/IErrorOr.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace ErrorOr;
 
 public interface IErrorOr<out TValue> : IErrorOr
@@ -19,7 +21,7 @@ public interface IErrorOr
     /// <summary>
     /// Gets the collection of errors.
     /// </summary>
-    IReadOnlyList<Error> Errors { get; }
+    ImmutableArray<Error> Errors { get; }
 
     /// <summary>
     /// Gets a value indicating whether the state is error.

--- a/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
@@ -86,7 +86,7 @@ public class ElseAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -120,7 +120,7 @@ public class ElseAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -154,7 +154,7 @@ public class ElseAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]

--- a/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
@@ -1,6 +1,3 @@
-using ErrorOr;
-using FluentAssertions;
-
 namespace Tests;
 
 public class ElseAsyncTests
@@ -18,8 +15,8 @@ public class ElseAsyncTests
             .ElseAsync(errors => Task.FromResult($"Error count: {errors.Count}"));
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().BeEquivalentTo(errorOrString.Value);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(errorOrString.Value);
     }
 
     [Fact]
@@ -35,8 +32,8 @@ public class ElseAsyncTests
             .ElseAsync(errors => Task.FromResult($"Error count: {errors.Count}"));
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().BeEquivalentTo("Error count: 1");
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe("Error count: 1");
     }
 
     [Fact]
@@ -52,8 +49,8 @@ public class ElseAsyncTests
             .ElseAsync(Task.FromResult("oh no"));
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().BeEquivalentTo(errorOrString.Value);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(errorOrString.Value);
     }
 
     [Fact]
@@ -69,8 +66,8 @@ public class ElseAsyncTests
             .ElseAsync(Task.FromResult("oh no"));
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().BeEquivalentTo("oh no");
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe("oh no");
     }
 
     [Fact]
@@ -86,8 +83,8 @@ public class ElseAsyncTests
             .ElseAsync(Task.FromResult(Error.Unexpected()));
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Unexpected);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -103,8 +100,8 @@ public class ElseAsyncTests
             .ElseAsync(Task.FromResult(Error.Unexpected()));
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().Be(errorOrString.Value);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(errorOrString.Value);
     }
 
     [Fact]
@@ -120,8 +117,8 @@ public class ElseAsyncTests
             .ElseAsync(errors => Task.FromResult(Error.Unexpected()));
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Unexpected);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -137,8 +134,8 @@ public class ElseAsyncTests
             .ElseAsync(errors => Task.FromResult(Error.Unexpected()));
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().Be(errorOrString.Value);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(errorOrString.Value);
     }
 
     [Fact]
@@ -154,8 +151,8 @@ public class ElseAsyncTests
             .ElseAsync(errors => Task.FromResult<IReadOnlyList<Error>>([Error.Unexpected()]));
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Unexpected);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -171,7 +168,7 @@ public class ElseAsyncTests
             .ElseAsync(errors => Task.FromResult<IReadOnlyList<Error>>([Error.Unexpected()]));
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().Be(errorOrString.Value);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(errorOrString.Value);
     }
 }

--- a/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseAsyncTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Tests;
 
 public class ElseAsyncTests
@@ -12,7 +14,7 @@ public class ElseAsyncTests
         ErrorOr<string> result = await errorOrString
             .ThenAsync(Convert.ToIntAsync)
             .ThenAsync(Convert.ToStringAsync)
-            .ElseAsync(errors => Task.FromResult($"Error count: {errors.Count}"));
+            .ElseAsync(errors => Task.FromResult($"Error count: {errors.Length}"));
 
         // Assert
         result.IsError.ShouldBeFalse();
@@ -29,7 +31,7 @@ public class ElseAsyncTests
         ErrorOr<string> result = await errorOrString
             .ThenAsync(Convert.ToIntAsync)
             .ThenAsync(Convert.ToStringAsync)
-            .ElseAsync(errors => Task.FromResult($"Error count: {errors.Count}"));
+            .ElseAsync(errors => Task.FromResult($"Error count: {errors.Length}"));
 
         // Assert
         result.IsError.ShouldBeFalse();
@@ -84,7 +86,7 @@ public class ElseAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -118,7 +120,7 @@ public class ElseAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -148,11 +150,11 @@ public class ElseAsyncTests
         ErrorOr<string> result = await errorOrString
             .ThenAsync(Convert.ToIntAsync)
             .ThenAsync(Convert.ToStringAsync)
-            .ElseAsync(errors => Task.FromResult<IReadOnlyList<Error>>([Error.Unexpected()]));
+            .ElseAsync(errors => Task.FromResult<ImmutableArray<Error>>([Error.Unexpected()]));
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -165,7 +167,7 @@ public class ElseAsyncTests
         ErrorOr<string> result = await errorOrString
             .ThenAsync(Convert.ToIntAsync)
             .ThenAsync(Convert.ToStringAsync)
-            .ElseAsync(errors => Task.FromResult<IReadOnlyList<Error>>([Error.Unexpected()]));
+            .ElseAsync(errors => Task.FromResult<ImmutableArray<Error>>([Error.Unexpected()]));
 
         // Assert
         result.IsError.ShouldBeFalse();

--- a/tests/ErrorOr/ErrorOr.ElseTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseTests.cs
@@ -12,7 +12,7 @@ public class ElseTests
         ErrorOr<string> result = errorOrString
             .Then(Convert.ToInt)
             .Then(Convert.ToString)
-            .Else(errors => $"Error count: {errors.Count}");
+            .Else(errors => $"Error count: {errors.Length}");
 
         // Assert
         result.IsError.ShouldBeFalse();
@@ -29,7 +29,7 @@ public class ElseTests
         ErrorOr<string> result = errorOrString
             .Then(Convert.ToInt)
             .Then(Convert.ToString)
-            .Else(errors => $"Error count: {errors.Count}");
+            .Else(errors => $"Error count: {errors.Length}");
 
         // Assert
         result.IsError.ShouldBeFalse();
@@ -84,7 +84,7 @@ public class ElseTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public class ElseTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -152,7 +152,7 @@ public class ElseTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -199,7 +199,7 @@ public class ElseTests
         ErrorOr<string> result = await errorOrString
             .Then(Convert.ToInt)
             .ThenAsync(Convert.ToStringAsync)
-            .Else(errors => $"Error count: {errors.Count}");
+            .Else(errors => $"Error count: {errors.Length}");
 
         // Assert
         result.IsError.ShouldBeFalse();
@@ -220,7 +220,7 @@ public class ElseTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -237,7 +237,7 @@ public class ElseTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -254,6 +254,6 @@ public class ElseTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
     }
 }

--- a/tests/ErrorOr/ErrorOr.ElseTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseTests.cs
@@ -84,7 +84,7 @@ public class ElseTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public class ElseTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -152,7 +152,7 @@ public class ElseTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -220,7 +220,7 @@ public class ElseTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -237,7 +237,7 @@ public class ElseTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -254,6 +254,6 @@ public class ElseTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Unexpected);
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 }

--- a/tests/ErrorOr/ErrorOr.ElseTests.cs
+++ b/tests/ErrorOr/ErrorOr.ElseTests.cs
@@ -1,6 +1,3 @@
-using ErrorOr;
-using FluentAssertions;
-
 namespace Tests;
 
 public class ElseTests
@@ -18,8 +15,8 @@ public class ElseTests
             .Else(errors => $"Error count: {errors.Count}");
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().BeEquivalentTo(errorOrString.Value);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(errorOrString.Value);
     }
 
     [Fact]
@@ -35,8 +32,8 @@ public class ElseTests
             .Else(errors => $"Error count: {errors.Count}");
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().BeEquivalentTo("Error count: 1");
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe("Error count: 1");
     }
 
     [Fact]
@@ -52,8 +49,8 @@ public class ElseTests
             .Else("oh no");
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().BeEquivalentTo(errorOrString.Value);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(errorOrString.Value);
     }
 
     [Fact]
@@ -69,8 +66,8 @@ public class ElseTests
             .Else("oh no");
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().BeEquivalentTo("oh no");
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe("oh no");
     }
 
     [Fact]
@@ -86,8 +83,8 @@ public class ElseTests
             .Else(Error.Unexpected());
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Unexpected);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -103,8 +100,8 @@ public class ElseTests
             .Else(Error.Unexpected());
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().Be(errorOrString.Value);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(errorOrString.Value);
     }
 
     [Fact]
@@ -120,8 +117,8 @@ public class ElseTests
             .Else(errors => Error.Unexpected());
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Unexpected);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -137,8 +134,8 @@ public class ElseTests
             .Else(errors => Error.Unexpected());
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().Be(errorOrString.Value);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(errorOrString.Value);
     }
 
     [Fact]
@@ -154,8 +151,8 @@ public class ElseTests
             .Else(errors => [Error.Unexpected()]);
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Unexpected);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -171,8 +168,8 @@ public class ElseTests
             .Else(errors => [Error.Unexpected()]);
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().Be(errorOrString.Value);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(errorOrString.Value);
     }
 
     [Fact]
@@ -188,8 +185,8 @@ public class ElseTests
             .Else("oh no");
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().BeEquivalentTo("oh no");
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe("oh no");
     }
 
     [Fact]
@@ -205,8 +202,8 @@ public class ElseTests
             .Else(errors => $"Error count: {errors.Count}");
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().BeEquivalentTo("Error count: 1");
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe("Error count: 1");
     }
 
     [Fact]
@@ -222,8 +219,8 @@ public class ElseTests
             .Else(Error.Unexpected());
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Unexpected);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -239,8 +236,8 @@ public class ElseTests
             .Else(errors => Error.Unexpected());
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Unexpected);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 
     [Fact]
@@ -256,7 +253,7 @@ public class ElseTests
             .Else(errors => [Error.Unexpected()]);
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Unexpected);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Unexpected);
     }
 }

--- a/tests/ErrorOr/ErrorOr.EqualityTests.cs
+++ b/tests/ErrorOr/ErrorOr.EqualityTests.cs
@@ -1,6 +1,3 @@
-﻿using ErrorOr;
-using FluentAssertions;
-
 namespace Tests;
 
 public sealed class ErrorOrEqualityTests
@@ -54,7 +51,7 @@ public sealed class ErrorOrEqualityTests
 
         var result = errorOrPerson1.Equals(errorOrPerson2);
 
-        result.Should().BeTrue();
+        result.ShouldBeTrue();
     }
 
     [Fact]
@@ -75,7 +72,7 @@ public sealed class ErrorOrEqualityTests
 
         var result = errorOrPerson1.Equals(errorOrPerson2);
 
-        result.Should().BeTrue();
+        result.ShouldBeTrue();
     }
 
     [Theory]
@@ -87,7 +84,7 @@ public sealed class ErrorOrEqualityTests
 
         var result = errorOrPerson1.Equals(errorOrPerson2);
 
-        result.Should().BeFalse();
+        result.ShouldBeFalse();
     }
 
     [Theory]
@@ -99,7 +96,7 @@ public sealed class ErrorOrEqualityTests
 
         var result = errorOrPerson1.Equals(errorOrPerson2);
 
-        result.Should().BeTrue();
+        result.ShouldBeTrue();
     }
 
     [Theory]
@@ -111,7 +108,7 @@ public sealed class ErrorOrEqualityTests
 
         var result = errorOrPerson1.Equals(errorOrPerson2);
 
-        result.Should().BeFalse();
+        result.ShouldBeFalse();
     }
 
     [Theory]
@@ -124,7 +121,7 @@ public sealed class ErrorOrEqualityTests
         var hashCode1 = errorOrPerson1.GetHashCode();
         var hashCode2 = errorOrPerson2.GetHashCode();
 
-        hashCode1.Should().Be(hashCode2);
+        hashCode1.ShouldBe(hashCode2);
     }
 
     [Theory]
@@ -139,7 +136,7 @@ public sealed class ErrorOrEqualityTests
         var hashCode1 = errorOrPerson1.GetHashCode();
         var hashCode2 = errorOrPerson2.GetHashCode();
 
-        hashCode1.Should().NotBe(hashCode2);
+        hashCode1.ShouldNotBe(hashCode2);
     }
 
     [Fact]
@@ -161,7 +158,7 @@ public sealed class ErrorOrEqualityTests
         var hashCode1 = errorOrPerson1.GetHashCode();
         var hashCode2 = errorOrPerson2.GetHashCode();
 
-        hashCode1.Should().Be(hashCode2);
+        hashCode1.ShouldBe(hashCode2);
     }
 
     [Theory]
@@ -176,6 +173,6 @@ public sealed class ErrorOrEqualityTests
         var hashCode1 = errorOrPerson1.GetHashCode();
         var hashCode2 = errorOrPerson2.GetHashCode();
 
-        hashCode1.Should().NotBe(hashCode2);
+        hashCode1.ShouldNotBe(hashCode2);
     }
 }

--- a/tests/ErrorOr/ErrorOr.FailIfAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.FailIfAsyncTests.cs
@@ -16,7 +16,7 @@ public class FailIfAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class FailIfAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
     }
 
     [Fact]
@@ -62,7 +62,7 @@ public class FailIfAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.NotFound);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.NotFound);
     }
 
     [Fact]
@@ -77,8 +77,8 @@ public class FailIfAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Failure);
-        result.FirstError.Description.ShouldBe("5 is greater than 3.");
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Value.Description.ShouldBe("5 is greater than 3.");
     }
 
     [Fact]
@@ -94,8 +94,8 @@ public class FailIfAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Failure);
-        result.FirstError.Description.ShouldBe("5 is greater than 3.");
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Value.Description.ShouldBe("5 is greater than 3.");
     }
 
     [Fact]
@@ -125,6 +125,6 @@ public class FailIfAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.NotFound);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.NotFound);
     }
 }

--- a/tests/ErrorOr/ErrorOr.FailIfAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.FailIfAsyncTests.cs
@@ -16,7 +16,7 @@ public class FailIfAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class FailIfAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
     }
 
     [Fact]
@@ -62,7 +62,7 @@ public class FailIfAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.NotFound);
+        result.FirstError.Type.ShouldBe(ErrorType.NotFound);
     }
 
     [Fact]
@@ -77,8 +77,8 @@ public class FailIfAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
-        result.FirstError.Value.Description.ShouldBe("5 is greater than 3.");
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Description.ShouldBe("5 is greater than 3.");
     }
 
     [Fact]
@@ -94,8 +94,8 @@ public class FailIfAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
-        result.FirstError.Value.Description.ShouldBe("5 is greater than 3.");
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Description.ShouldBe("5 is greater than 3.");
     }
 
     [Fact]
@@ -125,6 +125,6 @@ public class FailIfAsyncTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.NotFound);
+        result.FirstError.Type.ShouldBe(ErrorType.NotFound);
     }
 }

--- a/tests/ErrorOr/ErrorOr.FailIfAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.FailIfAsyncTests.cs
@@ -1,6 +1,3 @@
-using ErrorOr;
-using FluentAssertions;
-
 namespace Tests;
 
 public class FailIfAsyncTests
@@ -18,8 +15,8 @@ public class FailIfAsyncTests
             .FailIfAsync(num => Task.FromResult(num > 3), Error.Failure());
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Failure);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
     }
 
     [Fact]
@@ -34,8 +31,8 @@ public class FailIfAsyncTests
             .FailIfAsync(num => Task.FromResult(num > 3), Error.Failure());
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Failure);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
     }
 
     [Fact]
@@ -49,8 +46,8 @@ public class FailIfAsyncTests
             .FailIfAsync(num => Task.FromResult(num > 10), Error.Failure());
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().Be(5);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(5);
     }
 
     [Fact]
@@ -64,8 +61,8 @@ public class FailIfAsyncTests
             .FailIfAsync(str => Task.FromResult(str == string.Empty), Error.Failure());
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.NotFound);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.NotFound);
     }
 
     [Fact]
@@ -79,9 +76,9 @@ public class FailIfAsyncTests
             .FailIfAsync(num => Task.FromResult(num > 3), (num) => Task.FromResult(Error.Failure(description: $"{num} is greater than 3.")));
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Failure);
-        result.FirstError.Description.Should().Be("5 is greater than 3.");
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Description.ShouldBe("5 is greater than 3.");
     }
 
     [Fact]
@@ -96,9 +93,9 @@ public class FailIfAsyncTests
             .FailIfAsync(num => Task.FromResult(num > 3), (num) => Task.FromResult(Error.Failure(description: $"{num} is greater than 3.")));
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Failure);
-        result.FirstError.Description.Should().Be("5 is greater than 3.");
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Description.ShouldBe("5 is greater than 3.");
     }
 
     [Fact]
@@ -112,8 +109,8 @@ public class FailIfAsyncTests
             .FailIfAsync(num => Task.FromResult(num > 10), (num) => Task.FromResult(Error.Failure(description: $"{num} is greater than 10.")));
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().Be(5);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(5);
     }
 
     [Fact]
@@ -127,7 +124,7 @@ public class FailIfAsyncTests
             .FailIfAsync(num => Task.FromResult(num > 3), (num) => Task.FromResult(Error.Failure(description: $"{num} is greater than 3.")));
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.NotFound);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.NotFound);
     }
 }

--- a/tests/ErrorOr/ErrorOr.FailIfTests.cs
+++ b/tests/ErrorOr/ErrorOr.FailIfTests.cs
@@ -14,7 +14,7 @@ public class FailIfTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
     }
 
     [Fact]
@@ -30,7 +30,7 @@ public class FailIfTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
     }
 
     [Fact]
@@ -60,7 +60,7 @@ public class FailIfTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.NotFound);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.NotFound);
     }
 
     [Fact]
@@ -75,8 +75,8 @@ public class FailIfTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Failure);
-        result.FirstError.Description.ShouldBe("5 is greater than 3");
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Value.Description.ShouldBe("5 is greater than 3");
     }
 
     [Fact]
@@ -92,8 +92,8 @@ public class FailIfTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.Failure);
-        result.FirstError.Description.ShouldBe("5 is greater than 3");
+        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Value.Description.ShouldBe("5 is greater than 3");
     }
 
     [Fact]
@@ -123,6 +123,6 @@ public class FailIfTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Type.ShouldBe(ErrorType.NotFound);
+        result.FirstError.Value.Type.ShouldBe(ErrorType.NotFound);
     }
 }

--- a/tests/ErrorOr/ErrorOr.FailIfTests.cs
+++ b/tests/ErrorOr/ErrorOr.FailIfTests.cs
@@ -14,7 +14,7 @@ public class FailIfTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
     }
 
     [Fact]
@@ -30,7 +30,7 @@ public class FailIfTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
     }
 
     [Fact]
@@ -60,7 +60,7 @@ public class FailIfTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.NotFound);
+        result.FirstError.Type.ShouldBe(ErrorType.NotFound);
     }
 
     [Fact]
@@ -75,8 +75,8 @@ public class FailIfTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
-        result.FirstError.Value.Description.ShouldBe("5 is greater than 3");
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Description.ShouldBe("5 is greater than 3");
     }
 
     [Fact]
@@ -92,8 +92,8 @@ public class FailIfTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.Failure);
-        result.FirstError.Value.Description.ShouldBe("5 is greater than 3");
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Description.ShouldBe("5 is greater than 3");
     }
 
     [Fact]
@@ -123,6 +123,6 @@ public class FailIfTests
 
         // Assert
         result.IsError.ShouldBeTrue();
-        result.FirstError.Value.Type.ShouldBe(ErrorType.NotFound);
+        result.FirstError.Type.ShouldBe(ErrorType.NotFound);
     }
 }

--- a/tests/ErrorOr/ErrorOr.FailIfTests.cs
+++ b/tests/ErrorOr/ErrorOr.FailIfTests.cs
@@ -1,6 +1,3 @@
-using ErrorOr;
-using FluentAssertions;
-
 namespace Tests;
 
 public class FailIfTests
@@ -16,8 +13,8 @@ public class FailIfTests
             .FailIf(num => num > 3, Error.Failure());
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Failure);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
     }
 
     [Fact]
@@ -32,8 +29,8 @@ public class FailIfTests
             .FailIf(num => num > 3, Error.Failure());
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Failure);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
     }
 
     [Fact]
@@ -47,8 +44,8 @@ public class FailIfTests
             .FailIf(num => num > 10, Error.Failure());
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().Be(5);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(5);
     }
 
     [Fact]
@@ -62,8 +59,8 @@ public class FailIfTests
             .FailIf(str => str == string.Empty, Error.Failure());
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.NotFound);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.NotFound);
     }
 
     [Fact]
@@ -77,9 +74,9 @@ public class FailIfTests
             .FailIf(num => num > 3, (num) => Error.Failure(description: $"{num} is greater than 3"));
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Failure);
-        result.FirstError.Description.Should().Be("5 is greater than 3");
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Description.ShouldBe("5 is greater than 3");
     }
 
     [Fact]
@@ -94,9 +91,9 @@ public class FailIfTests
             .FailIf(num => num > 3, (num) => Error.Failure(description: $"{num} is greater than 3"));
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.Failure);
-        result.FirstError.Description.Should().Be("5 is greater than 3");
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.Failure);
+        result.FirstError.Description.ShouldBe("5 is greater than 3");
     }
 
     [Fact]
@@ -110,8 +107,8 @@ public class FailIfTests
             .FailIf(num => num > 10, (num) => Error.Failure(description: $"{num} is greater than 10"));
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().Be(5);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(5);
     }
 
     [Fact]
@@ -125,7 +122,7 @@ public class FailIfTests
             .FailIf(num => num > 3, (num) => Error.Failure(description: $"{num} is greater than 3"));
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Type.Should().Be(ErrorType.NotFound);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Type.ShouldBe(ErrorType.NotFound);
     }
 }

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -26,7 +26,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.Create(value);
 
         // Act & Assert
-        errorOrPerson.FirstError.ShouldBeNull();
+        errorOrPerson.FirstError.ShouldBe(default);
     }
 
     [Fact]
@@ -62,7 +62,7 @@ public class ErrorOrInstantiationTests
         ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.Create(value);
 
         // Act & Assert
-        errorOrPerson.FirstError.ShouldBeNull();
+        errorOrPerson.FirstError.ShouldBe(default);
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class ErrorOrInstantiationTests
     [Fact]
     public void ImplicitCastResult_WhenAccessingErrors_ShouldReturnEmptyList()
     {
-        ErrorOr<Person> errorOrPerson = new Person("Amichai");
+        ErrorOr<Person> errorOrPerson = new Person("Dmitry");
 
         // Act & Assert
         errorOrPerson.Errors.ShouldBeEmpty();
@@ -125,10 +125,10 @@ public class ErrorOrInstantiationTests
     [Fact]
     public void ImplicitCastResult_WhenAccessingFirstError_ShouldReturnNull()
     {
-        ErrorOr<Person> errorOrPerson = new Person("Amichai");
+        ErrorOr<Person> errorOrPerson = new Person("Dmitry");
 
         // Act & Assert
-        errorOrPerson.FirstError.ShouldBeNull();
+        errorOrPerson.FirstError.ShouldBe(default);
     }
 
     [Fact]

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -1,7 +1,5 @@
 namespace Tests;
 
-using ErrorOr;
-
 public class ErrorOrInstantiationTests
 {
     private record Person(string Name);
@@ -13,11 +11,33 @@ public class ErrorOrInstantiationTests
         IEnumerable<string> value = ["value"];
 
         // Act
-        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.From(value);
+        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.Create(value);
 
         // Assert
         errorOrPerson.IsError.ShouldBeFalse();
         errorOrPerson.Value.ShouldBeSameAs(value);
+    }
+
+    [Fact]
+    public void CreateFromFactory_WhenAccessingFirstError_ShouldReturnNull()
+    {
+        // Arrange
+        IEnumerable<string> value = ["value"];
+        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.Create(value);
+
+        // Act & Assert
+        errorOrPerson.FirstError.ShouldBeNull();
+    }
+
+    [Fact]
+    public void CreateFromFactory_WhenAccessingErrors_ShouldReturnEmptyList()
+    {
+        // Arrange
+        IEnumerable<string> value = ["value"];
+        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.Create(value);
+
+        // Act & Assert
+        errorOrPerson.Errors.ShouldBeEmpty();
     }
 
     [Fact]
@@ -27,7 +47,7 @@ public class ErrorOrInstantiationTests
         IEnumerable<string> value = ["value"];
 
         // Act
-        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.From(value);
+        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.Create(value);
 
         // Assert
         errorOrPerson.IsError.ShouldBeFalse();
@@ -35,15 +55,48 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void CreateFromValue_WhenAccessingFirstError_ShouldReturnNull()
+    {
+        // Arrange
+        IEnumerable<string> value = ["value"];
+        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.Create(value);
+
+        // Act & Assert
+        errorOrPerson.FirstError.ShouldBeNull();
+    }
+
+    [Fact]
+    public void CreateFromValue_WhenAccessingErrors_ShouldReturnEmptyList()
+    {
+        // Arrange
+        IEnumerable<string> value = ["value"];
+        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.Create(value);
+
+        // Act & Assert
+        errorOrPerson.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void CreateFromErrorList_WhenAccessingErrors_ShouldReturnErrorList()
     {
         // Arrange
-        List<Error> errors = new() { Error.Validation("User.Name", "Name is too short") };
-        ErrorOr<Person> errorOrPerson = ErrorOr<Person>.From(errors);
+        List<Error> errors = [Error.Validation("User.Name", "Name is too short")];
+        ErrorOr<Person> errorOrPerson = ErrorOrFactory.Create<Person>(errors);
 
         // Act & Assert
         errorOrPerson.IsError.ShouldBeTrue();
         errorOrPerson.Errors.ShouldHaveSingleItem().ShouldBe(errors.Single());
+    }
+
+    [Fact]
+    public void CreateFromErrorList_WhenAccessingValue_ShouldReturnNull()
+    {
+        // Arrange
+        List<Error> errors = [Error.Validation("User.Name", "Name is too short")];
+        ErrorOr<Person> errorOrPerson = ErrorOrFactory.Create<Person>(errors);
+
+        // Act & Assert
+        errorOrPerson.Value.ShouldBeNull();
     }
 
     [Fact]
@@ -58,6 +111,24 @@ public class ErrorOrInstantiationTests
         // Assert
         errorOr.IsError.ShouldBeFalse();
         errorOr.Value.ShouldBe(result);
+    }
+
+    [Fact]
+    public void ImplicitCastResult_WhenAccessingErrors_ShouldReturnEmptyList()
+    {
+        ErrorOr<Person> errorOrPerson = new Person("Amichai");
+
+        // Act & Assert
+        errorOrPerson.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ImplicitCastResult_WhenAccessingFirstError_ShouldReturnNull()
+    {
+        ErrorOr<Person> errorOrPerson = new Person("Amichai");
+
+        // Act & Assert
+        errorOrPerson.FirstError.ShouldBeNull();
     }
 
     [Fact]
@@ -112,6 +183,16 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void ImplicitCastError_WhenAccessingValue_ShouldReturnNull()
+    {
+        // Arrange
+        ErrorOr<Person> errorOrPerson = Error.Validation("User.Name", "Name is too short");
+
+        // Act & Assert
+        errorOrPerson.Value.ShouldBeNull();
+    }
+
+    [Fact]
     public void ImplicitCastSingleError_WhenAccessingFirstError_ShouldReturnError()
     {
         // Arrange
@@ -129,18 +210,18 @@ public class ErrorOrInstantiationTests
     public void ImplicitCastErrorList_WhenAccessingErrors_ShouldReturnErrorList()
     {
         // Arrange
-        List<Error> errors = new()
-        {
+        List<Error> errors =
+        [
             Error.Validation("User.Name", "Name is too short"),
             Error.Validation("User.Age", "User is too young"),
-        };
+        ];
 
         // Act
         ErrorOr<Person> errorOrPerson = errors;
 
         // Assert
         errorOrPerson.IsError.ShouldBeTrue();
-        errorOrPerson.Errors.Count.ShouldBe(errors.Count);
+        errorOrPerson.Errors.Length.ShouldBe(errors.Count);
         errorOrPerson.Errors.ShouldBe(errors);
     }
 
@@ -159,7 +240,7 @@ public class ErrorOrInstantiationTests
 
         // Assert
         errorOrPerson.IsError.ShouldBeTrue();
-        errorOrPerson.Errors.Count.ShouldBe(errors.Length);
+        errorOrPerson.Errors.Length.ShouldBe(errors.Length);
         errorOrPerson.Errors.ShouldBe(errors);
     }
 
@@ -167,11 +248,11 @@ public class ErrorOrInstantiationTests
     public void ImplicitCastErrorList_WhenAccessingFirstError_ShouldReturnFirstError()
     {
         // Arrange
-        List<Error> errors = new()
-        {
+        List<Error> errors =
+        [
             Error.Validation("User.Name", "Name is too short"),
             Error.Validation("User.Age", "User is too young"),
-        };
+        ];
 
         // Act
         ErrorOr<Person> errorOrPerson = errors;
@@ -203,9 +284,7 @@ public class ErrorOrInstantiationTests
     public void CreateErrorOr_WhenUsingEmptyConstructor_ShouldThrow()
     {
         // Act & Assert
-#pragma warning disable SA1129 // Do not use default value type constructor
         Should.Throw<InvalidOperationException>(() => { _ = new ErrorOr<int>(); });
-#pragma warning restore SA1129 // Do not use default value type constructor
     }
 
     [Fact]
@@ -213,7 +292,7 @@ public class ErrorOrInstantiationTests
     {
         // Act & Assert
         var exception = Should.Throw<ArgumentException>(() => { ErrorOr<int> errorOr = new List<Error>(); });
-        exception.Message.ShouldBe("Cannot create an ErrorOr<TValue> from an empty collection of errors. Provide at least one error. (Parameter 'errors')");
+        exception.Message.ShouldContain("Cannot create an ErrorOr<> from an empty collection of errors. Provide at least one error.");
         exception.ParamName.ShouldBe("errors");
     }
 
@@ -222,7 +301,7 @@ public class ErrorOrInstantiationTests
     {
         // Act & Assert
         var exception = Should.Throw<ArgumentException>(() => { ErrorOr<int> errorOr = Array.Empty<Error>(); });
-        exception.Message.ShouldBe("Cannot create an ErrorOr<TValue> from an empty collection of errors. Provide at least one error. (Parameter 'errors')");
+        exception.Message.ShouldContain("Cannot create an ErrorOr<> from an empty collection of errors. Provide at least one error.");
         exception.ParamName.ShouldBe("errors");
     }
 

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -1,7 +1,6 @@
 namespace Tests;
 
 using ErrorOr;
-using FluentAssertions;
 
 public class ErrorOrInstantiationTests
 {
@@ -17,8 +16,8 @@ public class ErrorOrInstantiationTests
         ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.From(value);
 
         // Assert
-        errorOrPerson.IsError.Should().BeFalse();
-        errorOrPerson.Value.Should().BeSameAs(value);
+        errorOrPerson.IsError.ShouldBeFalse();
+        errorOrPerson.Value.ShouldBeSameAs(value);
     }
 
     [Fact]
@@ -31,8 +30,8 @@ public class ErrorOrInstantiationTests
         ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.From(value);
 
         // Assert
-        errorOrPerson.IsError.Should().BeFalse();
-        errorOrPerson.Value.Should().BeSameAs(value);
+        errorOrPerson.IsError.ShouldBeFalse();
+        errorOrPerson.Value.ShouldBeSameAs(value);
     }
 
     [Fact]
@@ -43,8 +42,8 @@ public class ErrorOrInstantiationTests
         ErrorOr<Person> errorOrPerson = ErrorOr<Person>.From(errors);
 
         // Act & Assert
-        errorOrPerson.IsError.Should().BeTrue();
-        errorOrPerson.Errors.Should().ContainSingle().Which.Should().Be(errors.Single());
+        errorOrPerson.IsError.ShouldBeTrue();
+        errorOrPerson.Errors.ShouldHaveSingleItem().ShouldBe(errors.Single());
     }
 
     [Fact]
@@ -57,8 +56,8 @@ public class ErrorOrInstantiationTests
         ErrorOr<Person> errorOr = result;
 
         // Assert
-        errorOr.IsError.Should().BeFalse();
-        errorOr.Value.Should().Be(result);
+        errorOr.IsError.ShouldBeFalse();
+        errorOr.Value.ShouldBe(result);
     }
 
     [Fact]
@@ -71,8 +70,8 @@ public class ErrorOrInstantiationTests
         ErrorOr<int> errorOrInt = result;
 
         // Assert
-        errorOrInt.IsError.Should().BeFalse();
-        errorOrInt.Value.Should().Be(result);
+        errorOrInt.IsError.ShouldBeFalse();
+        errorOrInt.Value.ShouldBe(result);
     }
 
     [Fact]
@@ -85,17 +84,17 @@ public class ErrorOrInstantiationTests
         ErrorOr<Updated> errorOrUpdated = Result.Updated;
 
         // Assert
-        errorOrSuccess.IsError.Should().BeFalse();
-        errorOrSuccess.Value.Should().Be(Result.Success);
+        errorOrSuccess.IsError.ShouldBeFalse();
+        errorOrSuccess.Value.ShouldBe(Result.Success);
 
-        errorOrCreated.IsError.Should().BeFalse();
-        errorOrCreated.Value.Should().Be(Result.Created);
+        errorOrCreated.IsError.ShouldBeFalse();
+        errorOrCreated.Value.ShouldBe(Result.Created);
 
-        errorOrDeleted.IsError.Should().BeFalse();
-        errorOrDeleted.Value.Should().Be(Result.Deleted);
+        errorOrDeleted.IsError.ShouldBeFalse();
+        errorOrDeleted.Value.ShouldBe(Result.Deleted);
 
-        errorOrUpdated.IsError.Should().BeFalse();
-        errorOrUpdated.Value.Should().Be(Result.Updated);
+        errorOrUpdated.IsError.ShouldBeFalse();
+        errorOrUpdated.Value.ShouldBe(Result.Updated);
     }
 
     [Fact]
@@ -108,8 +107,8 @@ public class ErrorOrInstantiationTests
         ErrorOr<Person> errorOrPerson = error;
 
         // Assert
-        errorOrPerson.IsError.Should().BeTrue();
-        errorOrPerson.Errors.Should().ContainSingle().Which.Should().Be(error);
+        errorOrPerson.IsError.ShouldBeTrue();
+        errorOrPerson.Errors.ShouldHaveSingleItem().ShouldBe(error);
     }
 
     [Fact]
@@ -122,8 +121,8 @@ public class ErrorOrInstantiationTests
         ErrorOr<Person> errorOrPerson = error;
 
         // Assert
-        errorOrPerson.IsError.Should().BeTrue();
-        errorOrPerson.FirstError.Should().Be(error);
+        errorOrPerson.IsError.ShouldBeTrue();
+        errorOrPerson.FirstError.ShouldBe(error);
     }
 
     [Fact]
@@ -140,8 +139,9 @@ public class ErrorOrInstantiationTests
         ErrorOr<Person> errorOrPerson = errors;
 
         // Assert
-        errorOrPerson.IsError.Should().BeTrue();
-        errorOrPerson.Errors.Should().HaveCount(errors.Count).And.BeEquivalentTo(errors);
+        errorOrPerson.IsError.ShouldBeTrue();
+        errorOrPerson.Errors.Count.ShouldBe(errors.Count);
+        errorOrPerson.Errors.ShouldBe(errors);
     }
 
     [Fact]
@@ -158,8 +158,9 @@ public class ErrorOrInstantiationTests
         ErrorOr<Person> errorOrPerson = errors;
 
         // Assert
-        errorOrPerson.IsError.Should().BeTrue();
-        errorOrPerson.Errors.Should().HaveCount(errors.Length).And.BeEquivalentTo(errors);
+        errorOrPerson.IsError.ShouldBeTrue();
+        errorOrPerson.Errors.Count.ShouldBe(errors.Length);
+        errorOrPerson.Errors.ShouldBe(errors);
     }
 
     [Fact]
@@ -176,8 +177,8 @@ public class ErrorOrInstantiationTests
         ErrorOr<Person> errorOrPerson = errors;
 
         // Assert
-        errorOrPerson.IsError.Should().BeTrue();
-        errorOrPerson.FirstError.Should().Be(errors[0]);
+        errorOrPerson.IsError.ShouldBeTrue();
+        errorOrPerson.FirstError.ShouldBe(errors[0]);
     }
 
     [Fact]
@@ -194,70 +195,55 @@ public class ErrorOrInstantiationTests
         ErrorOr<Person> errorOrPerson = errors;
 
         // Assert
-        errorOrPerson.IsError.Should().BeTrue();
-        errorOrPerson.FirstError.Should().Be(errors[0]);
+        errorOrPerson.IsError.ShouldBeTrue();
+        errorOrPerson.FirstError.ShouldBe(errors[0]);
     }
 
     [Fact]
     public void CreateErrorOr_WhenUsingEmptyConstructor_ShouldThrow()
     {
-        // Act
+        // Act & Assert
 #pragma warning disable SA1129 // Do not use default value type constructor
-        Func<ErrorOr<int>> action = () => new ErrorOr<int>();
+        Should.Throw<InvalidOperationException>(() => { _ = new ErrorOr<int>(); });
 #pragma warning restore SA1129 // Do not use default value type constructor
-
-        // Assert
-        action.Should().ThrowExactly<InvalidOperationException>();
     }
 
     [Fact]
     public void CreateErrorOr_WhenEmptyErrorsList_ShouldThrow()
     {
-        // Act
-        Func<ErrorOr<int>> errorOrInt = () => new List<Error>();
-
-        // Assert
-        var exception = errorOrInt.Should().ThrowExactly<ArgumentException>().Which;
-        exception.Message.Should().Be("Cannot create an ErrorOr<TValue> from an empty collection of errors. Provide at least one error. (Parameter 'errors')");
-        exception.ParamName.Should().Be("errors");
+        // Act & Assert
+        var exception = Should.Throw<ArgumentException>(() => { ErrorOr<int> errorOr = new List<Error>(); });
+        exception.Message.ShouldBe("Cannot create an ErrorOr<TValue> from an empty collection of errors. Provide at least one error. (Parameter 'errors')");
+        exception.ParamName.ShouldBe("errors");
     }
 
     [Fact]
     public void CreateErrorOr_WhenEmptyErrorsArray_ShouldThrow()
     {
-        // Act
-        Func<ErrorOr<int>> errorOrInt = () => Array.Empty<Error>();
-
-        // Assert
-        var exception = errorOrInt.Should().ThrowExactly<ArgumentException>().Which;
-        exception.Message.Should().Be("Cannot create an ErrorOr<TValue> from an empty collection of errors. Provide at least one error. (Parameter 'errors')");
-        exception.ParamName.Should().Be("errors");
+        // Act & Assert
+        var exception = Should.Throw<ArgumentException>(() => { ErrorOr<int> errorOr = Array.Empty<Error>(); });
+        exception.Message.ShouldBe("Cannot create an ErrorOr<TValue> from an empty collection of errors. Provide at least one error. (Parameter 'errors')");
+        exception.ParamName.ShouldBe("errors");
     }
 
     [Fact]
     public void CreateErrorOr_WhenNullIsPassedAsErrorsList_ShouldThrowArgumentNullException()
     {
-        Func<ErrorOr<int>> act = () => default(List<Error>)!;
-
-        act.Should().ThrowExactly<ArgumentNullException>()
-           .And.ParamName.Should().Be("errors");
+        var exception = Should.Throw<ArgumentNullException>(() => { ErrorOr<int> errorOr = default(List<Error>)!; });
+        exception.ParamName.ShouldBe("errors");
     }
 
     [Fact]
     public void CreateErrorOr_WhenNullIsPassedAsErrorsArray_ShouldThrowArgumentNullException()
     {
-        Func<ErrorOr<int>> act = () => default(Error[])!;
-
-        act.Should().ThrowExactly<ArgumentNullException>()
-           .And.ParamName.Should().Be("errors");
+        var exception = Should.Throw<ArgumentNullException>(() => { ErrorOr<int> errorOr = default(Error[])!; });
+        exception.ParamName.ShouldBe("errors");
     }
 
     [Fact]
     public void CreateErrorOr_WhenValueIsNull_ShouldThrowArgumentNullException()
     {
-        Func<ErrorOr<int?>> act = () => default(int?);
-
-        act.Should().ThrowExactly<ArgumentNullException>()
-           .And.ParamName.Should().Be("value");
+        var exception = Should.Throw<ArgumentNullException>(() => { ErrorOr<int?> errorOr = default(int?); });
+        exception.ParamName.ShouldBe("value");
     }
 }

--- a/tests/ErrorOr/ErrorOr.MatchAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.MatchAsyncTests.cs
@@ -1,6 +1,3 @@
-using ErrorOr;
-using FluentAssertions;
-
 namespace Tests;
 
 public class MatchAsyncTests
@@ -14,19 +11,19 @@ public class MatchAsyncTests
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
         Task<string> ThenAction(Person person)
         {
-            person.Should().BeEquivalentTo(errorOrPerson.Value);
+            person.ShouldBe(errorOrPerson.Value);
             return Task.FromResult("Nice");
         }
 
         Task<string> ElsesAction(IReadOnlyList<Error> _) => throw new Exception("Should not be called");
 
         // Act
-        Func<Task<string>> action = async () => await errorOrPerson.MatchAsync(
+        string result = await errorOrPerson.MatchAsync(
             ThenAction,
             ElsesAction);
 
         // Assert
-        (await action.Should().NotThrowAsync()).Subject.Should().Be("Nice");
+        result.ShouldBe("Nice");
     }
 
     [Fact]
@@ -38,17 +35,17 @@ public class MatchAsyncTests
 
         Task<string> ElsesAction(IReadOnlyList<Error> errors)
         {
-            errors.Should().BeEquivalentTo(errorOrPerson.Errors);
+            errors.ShouldBe(errorOrPerson.Errors);
             return Task.FromResult("Nice");
         }
 
         // Act
-        Func<Task<string>> action = async () => await errorOrPerson.MatchAsync(
+        string result = await errorOrPerson.MatchAsync(
             ThenAction,
             ElsesAction);
 
         // Assert
-        (await action.Should().NotThrowAsync()).Subject.Should().Be("Nice");
+        result.ShouldBe("Nice");
     }
 
     [Fact]
@@ -58,19 +55,19 @@ public class MatchAsyncTests
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
         Task<string> ThenAction(Person person)
         {
-            person.Should().BeEquivalentTo(errorOrPerson.Value);
+            person.ShouldBe(errorOrPerson.Value);
             return Task.FromResult("Nice");
         }
 
         Task<string> OnFirstErrorAction(Error _) => throw new Exception("Should not be called");
 
         // Act
-        Func<Task<string>> action = async () => await errorOrPerson.MatchFirstAsync(
+        string result = await errorOrPerson.MatchFirstAsync(
             ThenAction,
             OnFirstErrorAction);
 
         // Assert
-        (await action.Should().NotThrowAsync()).Subject.Should().Be("Nice");
+        result.ShouldBe("Nice");
     }
 
     [Fact]
@@ -81,19 +78,19 @@ public class MatchAsyncTests
         Task<string> ThenAction(Person _) => throw new Exception("Should not be called");
         Task<string> OnFirstErrorAction(Error errors)
         {
-            errors.Should().BeEquivalentTo(errorOrPerson.Errors.First())
-                .And.BeEquivalentTo(errorOrPerson.FirstError);
+            errors.ShouldBe(errorOrPerson.Errors.First());
+            errors.ShouldBe(errorOrPerson.FirstError);
 
             return Task.FromResult("Nice");
         }
 
         // Act
-        Func<Task<string>> action = async () => await errorOrPerson.MatchFirstAsync(
+        string result = await errorOrPerson.MatchFirstAsync(
             ThenAction,
             OnFirstErrorAction);
 
         // Assert
-        (await action.Should().NotThrowAsync()).Subject.Should().Be("Nice");
+        result.ShouldBe("Nice");
     }
 
     [Fact]
@@ -104,19 +101,19 @@ public class MatchAsyncTests
         Task<string> ThenAction(Person _) => throw new Exception("Should not be called");
         Task<string> OnFirstErrorAction(Error errors)
         {
-            errors.Should().BeEquivalentTo(errorOrPerson.Errors.First())
-                .And.BeEquivalentTo(errorOrPerson.FirstError);
+            errors.ShouldBe(errorOrPerson.Errors.First());
+            errors.ShouldBe(errorOrPerson.FirstError);
 
             return Task.FromResult("Nice");
         }
 
         // Act
-        Func<Task<string>> action = () => errorOrPerson
+        string result = await errorOrPerson
             .ThenAsync(person => Task.FromResult(person))
             .MatchFirstAsync(ThenAction, OnFirstErrorAction);
 
         // Assert
-        (await action.Should().NotThrowAsync()).Subject.Should().Be("Nice");
+        result.ShouldBe("Nice");
     }
 
     [Fact]
@@ -128,16 +125,16 @@ public class MatchAsyncTests
 
         Task<string> ElsesAction(IReadOnlyList<Error> errors)
         {
-            errors.Should().BeEquivalentTo(errorOrPerson.Errors);
+            errors.ShouldBe(errorOrPerson.Errors);
             return Task.FromResult("Nice");
         }
 
         // Act
-        Func<Task<string>> action = () => errorOrPerson
+        string result = await errorOrPerson
             .ThenAsync(person => Task.FromResult(person))
             .MatchAsync(ThenAction, ElsesAction);
 
         // Assert
-        (await action.Should().NotThrowAsync()).Subject.Should().Be("Nice");
+        result.ShouldBe("Nice");
     }
 }

--- a/tests/ErrorOr/ErrorOr.MatchAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.MatchAsyncTests.cs
@@ -82,7 +82,7 @@ public class MatchAsyncTests
         {
             errorOrPerson.IsError.ShouldBeTrue();
             errors.ShouldBe(errorOrPerson.Errors.First());
-            errors.ShouldBe(errorOrPerson.FirstError.Value);
+            errors.ShouldBe(errorOrPerson.FirstError);
 
             return Task.FromResult("Nice");
         }
@@ -106,7 +106,7 @@ public class MatchAsyncTests
         {
             errorOrPerson.IsError.ShouldBeTrue();
             errors.ShouldBe(errorOrPerson.Errors.First());
-            errors.ShouldBe(errorOrPerson.FirstError.Value);
+            errors.ShouldBe(errorOrPerson.FirstError);
 
             return Task.FromResult("Nice");
         }

--- a/tests/ErrorOr/ErrorOr.MatchAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.MatchAsyncTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Tests;
 
 public class MatchAsyncTests
@@ -15,7 +17,7 @@ public class MatchAsyncTests
             return Task.FromResult("Nice");
         }
 
-        Task<string> ElsesAction(IReadOnlyList<Error> _) => throw new Exception("Should not be called");
+        Task<string> ElsesAction(ImmutableArray<Error> _) => throw new Exception("Should not be called");
 
         // Act
         string result = await errorOrPerson.MatchAsync(
@@ -33,7 +35,7 @@ public class MatchAsyncTests
         ErrorOr<Person> errorOrPerson = new List<Error> { Error.Validation(), Error.Conflict() };
         Task<string> ThenAction(Person _) => throw new Exception("Should not be called");
 
-        Task<string> ElsesAction(IReadOnlyList<Error> errors)
+        Task<string> ElsesAction(ImmutableArray<Error> errors)
         {
             errors.ShouldBe(errorOrPerson.Errors);
             return Task.FromResult("Nice");
@@ -78,8 +80,9 @@ public class MatchAsyncTests
         Task<string> ThenAction(Person _) => throw new Exception("Should not be called");
         Task<string> OnFirstErrorAction(Error errors)
         {
+            errorOrPerson.IsError.ShouldBeTrue();
             errors.ShouldBe(errorOrPerson.Errors.First());
-            errors.ShouldBe(errorOrPerson.FirstError);
+            errors.ShouldBe(errorOrPerson.FirstError.Value);
 
             return Task.FromResult("Nice");
         }
@@ -101,8 +104,9 @@ public class MatchAsyncTests
         Task<string> ThenAction(Person _) => throw new Exception("Should not be called");
         Task<string> OnFirstErrorAction(Error errors)
         {
+            errorOrPerson.IsError.ShouldBeTrue();
             errors.ShouldBe(errorOrPerson.Errors.First());
-            errors.ShouldBe(errorOrPerson.FirstError);
+            errors.ShouldBe(errorOrPerson.FirstError.Value);
 
             return Task.FromResult("Nice");
         }
@@ -123,7 +127,7 @@ public class MatchAsyncTests
         ErrorOr<Person> errorOrPerson = new List<Error> { Error.Validation(), Error.Conflict() };
         Task<string> ThenAction(Person _) => throw new Exception("Should not be called");
 
-        Task<string> ElsesAction(IReadOnlyList<Error> errors)
+        Task<string> ElsesAction(ImmutableArray<Error> errors)
         {
             errors.ShouldBe(errorOrPerson.Errors);
             return Task.FromResult("Nice");

--- a/tests/ErrorOr/ErrorOr.MatchTests.cs
+++ b/tests/ErrorOr/ErrorOr.MatchTests.cs
@@ -1,6 +1,3 @@
-using ErrorOr;
-using FluentAssertions;
-
 namespace Tests;
 
 public class MatchTests
@@ -14,19 +11,19 @@ public class MatchTests
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
         string ThenAction(Person person)
         {
-            person.Should().BeEquivalentTo(errorOrPerson.Value);
+            person.ShouldBe(errorOrPerson.Value);
             return "Nice";
         }
 
         string ElsesAction(IReadOnlyList<Error> _) => throw new Exception("Should not be called");
 
         // Act
-        Func<string> action = () => errorOrPerson.Match(
+        string result = errorOrPerson.Match(
             ThenAction,
             ElsesAction);
 
         // Assert
-        action.Should().NotThrow().Subject.Should().Be("Nice");
+        result.ShouldBe("Nice");
     }
 
     [Fact]
@@ -38,17 +35,17 @@ public class MatchTests
 
         string ElsesAction(IReadOnlyList<Error> errors)
         {
-            errors.Should().BeEquivalentTo(errorOrPerson.Errors);
+            errors.ShouldBe(errorOrPerson.Errors);
             return "Nice";
         }
 
         // Act
-        Func<string> action = () => errorOrPerson.Match(
+        string result = errorOrPerson.Match(
             ThenAction,
             ElsesAction);
 
         // Assert
-        action.Should().NotThrow().Subject.Should().Be("Nice");
+        result.ShouldBe("Nice");
     }
 
     [Fact]
@@ -58,19 +55,19 @@ public class MatchTests
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
         string ThenAction(Person person)
         {
-            person.Should().BeEquivalentTo(errorOrPerson.Value);
+            person.ShouldBe(errorOrPerson.Value);
             return "Nice";
         }
 
         string OnFirstErrorAction(Error _) => throw new Exception("Should not be called");
 
         // Act
-        Func<string> action = () => errorOrPerson.MatchFirst(
+        string result = errorOrPerson.MatchFirst(
             ThenAction,
             OnFirstErrorAction);
 
         // Assert
-        action.Should().NotThrow().Subject.Should().Be("Nice");
+        result.ShouldBe("Nice");
     }
 
     [Fact]
@@ -81,19 +78,19 @@ public class MatchTests
         string ThenAction(Person _) => throw new Exception("Should not be called");
         string OnFirstErrorAction(Error errors)
         {
-            errors.Should().BeEquivalentTo(errorOrPerson.Errors[0])
-                .And.BeEquivalentTo(errorOrPerson.FirstError);
+            errors.ShouldBe(errorOrPerson.Errors[0]);
+            errors.ShouldBe(errorOrPerson.FirstError);
 
             return "Nice";
         }
 
         // Act
-        Func<string> action = () => errorOrPerson.MatchFirst(
+        string result = errorOrPerson.MatchFirst(
             ThenAction,
             OnFirstErrorAction);
 
         // Assert
-        action.Should().NotThrow().Subject.Should().Be("Nice");
+        result.ShouldBe("Nice");
     }
 
     [Fact]
@@ -103,19 +100,19 @@ public class MatchTests
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
         string ThenAction(Person person)
         {
-            person.Should().BeEquivalentTo(errorOrPerson.Value);
+            person.ShouldBe(errorOrPerson.Value);
             return "Nice";
         }
 
         string OnFirstErrorAction(Error _) => throw new Exception("Should not be called");
 
         // Act
-        Func<Task<string>> action = () => errorOrPerson
+        string result = await errorOrPerson
             .ThenAsync(person => Task.FromResult(person))
             .MatchFirst(ThenAction, OnFirstErrorAction);
 
         // Assert
-        (await action.Should().NotThrowAsync()).Subject.Should().Be("Nice");
+        result.ShouldBe("Nice");
     }
 
     [Fact]
@@ -125,18 +122,18 @@ public class MatchTests
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
         string ThenAction(Person person)
         {
-            person.Should().BeEquivalentTo(errorOrPerson.Value);
+            person.ShouldBe(errorOrPerson.Value);
             return "Nice";
         }
 
         string ElsesAction(IReadOnlyList<Error> _) => throw new Exception("Should not be called");
 
         // Act
-        Func<Task<string>> action = () => errorOrPerson
+        string result = await errorOrPerson
             .ThenAsync(person => Task.FromResult(person))
             .Match(ThenAction, ElsesAction);
 
         // Assert
-        (await action.Should().NotThrowAsync()).Subject.Should().Be("Nice");
+        result.ShouldBe("Nice");
     }
 }

--- a/tests/ErrorOr/ErrorOr.MatchTests.cs
+++ b/tests/ErrorOr/ErrorOr.MatchTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Tests;
 
 public class MatchTests
@@ -15,7 +17,7 @@ public class MatchTests
             return "Nice";
         }
 
-        string ElsesAction(IReadOnlyList<Error> _) => throw new Exception("Should not be called");
+        string ElsesAction(ImmutableArray<Error> _) => throw new Exception("Should not be called");
 
         // Act
         string result = errorOrPerson.Match(
@@ -33,7 +35,7 @@ public class MatchTests
         ErrorOr<Person> errorOrPerson = new List<Error> { Error.Validation(), Error.Conflict() };
         string ThenAction(Person _) => throw new Exception("Should not be called");
 
-        string ElsesAction(IReadOnlyList<Error> errors)
+        string ElsesAction(ImmutableArray<Error> errors)
         {
             errors.ShouldBe(errorOrPerson.Errors);
             return "Nice";
@@ -78,8 +80,9 @@ public class MatchTests
         string ThenAction(Person _) => throw new Exception("Should not be called");
         string OnFirstErrorAction(Error errors)
         {
+            errorOrPerson.IsError.ShouldBeTrue();
             errors.ShouldBe(errorOrPerson.Errors[0]);
-            errors.ShouldBe(errorOrPerson.FirstError);
+            errors.ShouldBe(errorOrPerson.FirstError.Value);
 
             return "Nice";
         }
@@ -126,7 +129,7 @@ public class MatchTests
             return "Nice";
         }
 
-        string ElsesAction(IReadOnlyList<Error> _) => throw new Exception("Should not be called");
+        string ElsesAction(ImmutableArray<Error> _) => throw new Exception("Should not be called");
 
         // Act
         string result = await errorOrPerson

--- a/tests/ErrorOr/ErrorOr.MatchTests.cs
+++ b/tests/ErrorOr/ErrorOr.MatchTests.cs
@@ -82,7 +82,7 @@ public class MatchTests
         {
             errorOrPerson.IsError.ShouldBeTrue();
             errors.ShouldBe(errorOrPerson.Errors[0]);
-            errors.ShouldBe(errorOrPerson.FirstError.Value);
+            errors.ShouldBe(errorOrPerson.FirstError);
 
             return "Nice";
         }

--- a/tests/ErrorOr/ErrorOr.SwitchAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.SwitchAsyncTests.cs
@@ -81,7 +81,7 @@ public class SwitchAsyncTests
         {
             errorOrPerson.IsError.ShouldBeTrue();
             errors.ShouldBe(errorOrPerson.Errors[0]);
-            errors.ShouldBe(errorOrPerson.FirstError.Value);
+            errors.ShouldBe(errorOrPerson.FirstError);
             return Task.CompletedTask;
         }
 

--- a/tests/ErrorOr/ErrorOr.SwitchAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.SwitchAsyncTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Tests;
 
 public class SwitchAsyncTests
@@ -15,7 +17,7 @@ public class SwitchAsyncTests
             return Task.CompletedTask;
         }
 
-        Task ElsesAction(IReadOnlyList<Error> _) => throw new Exception("Should not be called");
+        Task ElsesAction(ImmutableArray<Error> _) => throw new Exception("Should not be called");
 
         // Act
         Func<Task> action = async () => await errorOrPerson.SwitchAsync(
@@ -32,7 +34,7 @@ public class SwitchAsyncTests
         // Arrange
         ErrorOr<Person> errorOrPerson = new List<Error> { Error.Validation(), Error.Conflict() };
         Task ThenAction(Person _) => throw new Exception("Should not be called");
-        Task ElsesAction(IReadOnlyList<Error> errors)
+        Task ElsesAction(ImmutableArray<Error> errors)
         {
             errors.ShouldBe(errorOrPerson.Errors);
             return Task.CompletedTask;
@@ -77,8 +79,9 @@ public class SwitchAsyncTests
         Task ThenAction(Person _) => throw new Exception("Should not be called");
         Task OnFirstErrorAction(Error errors)
         {
+            errorOrPerson.IsError.ShouldBeTrue();
             errors.ShouldBe(errorOrPerson.Errors[0]);
-            errors.ShouldBe(errorOrPerson.FirstError);
+            errors.ShouldBe(errorOrPerson.FirstError.Value);
             return Task.CompletedTask;
         }
 
@@ -126,7 +129,7 @@ public class SwitchAsyncTests
             return Task.CompletedTask;
         }
 
-        Task ElsesAction(IReadOnlyList<Error> _) => throw new Exception("Should not be called");
+        Task ElsesAction(ImmutableArray<Error> _) => throw new Exception("Should not be called");
 
         // Act
         Func<Task> action = async () => await errorOrPerson

--- a/tests/ErrorOr/ErrorOr.SwitchAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.SwitchAsyncTests.cs
@@ -1,6 +1,3 @@
-using ErrorOr;
-using FluentAssertions;
-
 namespace Tests;
 
 public class SwitchAsyncTests
@@ -12,7 +9,12 @@ public class SwitchAsyncTests
     {
         // Arrange
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
-        Task ThenAction(Person person) => Task.FromResult(person.Should().BeEquivalentTo(errorOrPerson.Value));
+        Task ThenAction(Person person)
+        {
+            person.ShouldBe(errorOrPerson.Value);
+            return Task.CompletedTask;
+        }
+
         Task ElsesAction(IReadOnlyList<Error> _) => throw new Exception("Should not be called");
 
         // Act
@@ -21,7 +23,7 @@ public class SwitchAsyncTests
             ElsesAction);
 
         // Assert
-        await action.Should().NotThrowAsync();
+        await Should.NotThrowAsync(action);
     }
 
     [Fact]
@@ -30,7 +32,11 @@ public class SwitchAsyncTests
         // Arrange
         ErrorOr<Person> errorOrPerson = new List<Error> { Error.Validation(), Error.Conflict() };
         Task ThenAction(Person _) => throw new Exception("Should not be called");
-        Task ElsesAction(IReadOnlyList<Error> errors) => Task.FromResult(errors.Should().BeEquivalentTo(errorOrPerson.Errors));
+        Task ElsesAction(IReadOnlyList<Error> errors)
+        {
+            errors.ShouldBe(errorOrPerson.Errors);
+            return Task.CompletedTask;
+        }
 
         // Act
         Func<Task> action = async () => await errorOrPerson.SwitchAsync(
@@ -38,7 +44,7 @@ public class SwitchAsyncTests
             ElsesAction);
 
         // Assert
-        await action.Should().NotThrowAsync();
+        await Should.NotThrowAsync(action);
     }
 
     [Fact]
@@ -46,7 +52,12 @@ public class SwitchAsyncTests
     {
         // Arrange
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
-        Task ThenAction(Person person) => Task.FromResult(person.Should().BeEquivalentTo(errorOrPerson.Value));
+        Task ThenAction(Person person)
+        {
+            person.ShouldBe(errorOrPerson.Value);
+            return Task.CompletedTask;
+        }
+
         Task OnFirstErrorAction(Error _) => throw new Exception("Should not be called");
 
         // Act
@@ -55,7 +66,7 @@ public class SwitchAsyncTests
             OnFirstErrorAction);
 
         // Assert
-        await action.Should().NotThrowAsync();
+        await Should.NotThrowAsync(action);
     }
 
     [Fact]
@@ -65,8 +76,11 @@ public class SwitchAsyncTests
         ErrorOr<Person> errorOrPerson = new List<Error> { Error.Validation(), Error.Conflict() };
         Task ThenAction(Person _) => throw new Exception("Should not be called");
         Task OnFirstErrorAction(Error errors)
-            => Task.FromResult(errors.Should().BeEquivalentTo(errorOrPerson.Errors[0])
-                .And.BeEquivalentTo(errorOrPerson.FirstError));
+        {
+            errors.ShouldBe(errorOrPerson.Errors[0]);
+            errors.ShouldBe(errorOrPerson.FirstError);
+            return Task.CompletedTask;
+        }
 
         // Act
         Func<Task> action = async () => await errorOrPerson.SwitchFirstAsync(
@@ -74,7 +88,7 @@ public class SwitchAsyncTests
             OnFirstErrorAction);
 
         // Assert
-        await action.Should().NotThrowAsync();
+        await Should.NotThrowAsync(action);
     }
 
     [Fact]
@@ -82,7 +96,12 @@ public class SwitchAsyncTests
     {
         // Arrange
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
-        Task ThenAction(Person person) => Task.FromResult(person.Should().BeEquivalentTo(errorOrPerson.Value));
+        Task ThenAction(Person person)
+        {
+            person.ShouldBe(errorOrPerson.Value);
+            return Task.CompletedTask;
+        }
+
         Task OnFirstErrorAction(Error _) => throw new Exception("Should not be called");
 
         // Act
@@ -93,7 +112,7 @@ public class SwitchAsyncTests
                 OnFirstErrorAction);
 
         // Assert
-        await action.Should().NotThrowAsync();
+        await Should.NotThrowAsync(action);
     }
 
     [Fact]
@@ -101,7 +120,12 @@ public class SwitchAsyncTests
     {
         // Arrange
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
-        Task ThenAction(Person person) => Task.FromResult(person.Should().BeEquivalentTo(errorOrPerson.Value));
+        Task ThenAction(Person person)
+        {
+            person.ShouldBe(errorOrPerson.Value);
+            return Task.CompletedTask;
+        }
+
         Task ElsesAction(IReadOnlyList<Error> _) => throw new Exception("Should not be called");
 
         // Act
@@ -110,6 +134,6 @@ public class SwitchAsyncTests
             .SwitchAsync(ThenAction, ElsesAction);
 
         // Assert
-        await action.Should().NotThrowAsync();
+        await Should.NotThrowAsync(action);
     }
 }

--- a/tests/ErrorOr/ErrorOr.SwitchTests.cs
+++ b/tests/ErrorOr/ErrorOr.SwitchTests.cs
@@ -67,7 +67,7 @@ public class SwitchTests
         {
             errorOrPerson.IsError.ShouldBeTrue();
             errors.ShouldBe(errorOrPerson.Errors[0]);
-            errors.ShouldBe(errorOrPerson.FirstError.Value);
+            errors.ShouldBe(errorOrPerson.FirstError);
         }
 
         // Act

--- a/tests/ErrorOr/ErrorOr.SwitchTests.cs
+++ b/tests/ErrorOr/ErrorOr.SwitchTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Tests;
 
 public class SwitchTests
@@ -10,7 +12,7 @@ public class SwitchTests
         // Arrange
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
         void ThenAction(Person person) => person.ShouldBe(errorOrPerson.Value);
-        void ElsesAction(IReadOnlyList<Error> _) => throw new Exception("Should not be called");
+        void ElsesAction(ImmutableArray<Error> _) => throw new Exception("Should not be called");
 
         // Act
         Action action = () => errorOrPerson.Switch(
@@ -27,7 +29,7 @@ public class SwitchTests
         // Arrange
         ErrorOr<Person> errorOrPerson = new List<Error> { Error.Validation(), Error.Conflict() };
         void ThenAction(Person _) => throw new Exception("Should not be called");
-        void ElsesAction(IReadOnlyList<Error> errors) => errors.ShouldBe(errorOrPerson.Errors);
+        void ElsesAction(ImmutableArray<Error> errors) => errors.ShouldBe(errorOrPerson.Errors);
 
         // Act
         Action action = () => errorOrPerson.Switch(
@@ -63,8 +65,9 @@ public class SwitchTests
         void ThenAction(Person _) => throw new Exception("Should not be called");
         void OnFirstErrorAction(Error errors)
         {
+            errorOrPerson.IsError.ShouldBeTrue();
             errors.ShouldBe(errorOrPerson.Errors[0]);
-            errors.ShouldBe(errorOrPerson.FirstError);
+            errors.ShouldBe(errorOrPerson.FirstError.Value);
         }
 
         // Act
@@ -99,7 +102,7 @@ public class SwitchTests
         // Arrange
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
         void ThenAction(Person person) => person.ShouldBe(errorOrPerson.Value);
-        void ElsesAction(IReadOnlyList<Error> _) => throw new Exception("Should not be called");
+        void ElsesAction(ImmutableArray<Error> _) => throw new Exception("Should not be called");
 
         // Act
         Func<Task> action = () => errorOrPerson

--- a/tests/ErrorOr/ErrorOr.SwitchTests.cs
+++ b/tests/ErrorOr/ErrorOr.SwitchTests.cs
@@ -1,6 +1,3 @@
-using ErrorOr;
-using FluentAssertions;
-
 namespace Tests;
 
 public class SwitchTests
@@ -12,7 +9,7 @@ public class SwitchTests
     {
         // Arrange
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
-        void ThenAction(Person person) => person.Should().BeEquivalentTo(errorOrPerson.Value);
+        void ThenAction(Person person) => person.ShouldBe(errorOrPerson.Value);
         void ElsesAction(IReadOnlyList<Error> _) => throw new Exception("Should not be called");
 
         // Act
@@ -21,7 +18,7 @@ public class SwitchTests
             ElsesAction);
 
         // Assert
-        action.Should().NotThrow();
+        Should.NotThrow(action);
     }
 
     [Fact]
@@ -30,7 +27,7 @@ public class SwitchTests
         // Arrange
         ErrorOr<Person> errorOrPerson = new List<Error> { Error.Validation(), Error.Conflict() };
         void ThenAction(Person _) => throw new Exception("Should not be called");
-        void ElsesAction(IReadOnlyList<Error> errors) => errors.Should().BeEquivalentTo(errorOrPerson.Errors);
+        void ElsesAction(IReadOnlyList<Error> errors) => errors.ShouldBe(errorOrPerson.Errors);
 
         // Act
         Action action = () => errorOrPerson.Switch(
@@ -38,7 +35,7 @@ public class SwitchTests
             ElsesAction);
 
         // Assert
-        action.Should().NotThrow();
+        Should.NotThrow(action);
     }
 
     [Fact]
@@ -46,7 +43,7 @@ public class SwitchTests
     {
         // Arrange
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
-        void ThenAction(Person person) => person.Should().BeEquivalentTo(errorOrPerson.Value);
+        void ThenAction(Person person) => person.ShouldBe(errorOrPerson.Value);
         void OnFirstErrorAction(Error _) => throw new Exception("Should not be called");
 
         // Act
@@ -55,7 +52,7 @@ public class SwitchTests
             OnFirstErrorAction);
 
         // Assert
-        action.Should().NotThrow();
+        Should.NotThrow(action);
     }
 
     [Fact]
@@ -65,8 +62,10 @@ public class SwitchTests
         ErrorOr<Person> errorOrPerson = new List<Error> { Error.Validation(), Error.Conflict() };
         void ThenAction(Person _) => throw new Exception("Should not be called");
         void OnFirstErrorAction(Error errors)
-            => errors.Should().BeEquivalentTo(errorOrPerson.Errors[0])
-                .And.BeEquivalentTo(errorOrPerson.FirstError);
+        {
+            errors.ShouldBe(errorOrPerson.Errors[0]);
+            errors.ShouldBe(errorOrPerson.FirstError);
+        }
 
         // Act
         Action action = () => errorOrPerson.SwitchFirst(
@@ -74,7 +73,7 @@ public class SwitchTests
             OnFirstErrorAction);
 
         // Assert
-        action.Should().NotThrow();
+        Should.NotThrow(action);
     }
 
     [Fact]
@@ -82,7 +81,7 @@ public class SwitchTests
     {
         // Arrange
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
-        void ThenAction(Person person) => person.Should().BeEquivalentTo(errorOrPerson.Value);
+        void ThenAction(Person person) => person.ShouldBe(errorOrPerson.Value);
         void OnFirstErrorAction(Error _) => throw new Exception("Should not be called");
 
         // Act
@@ -91,7 +90,7 @@ public class SwitchTests
             .SwitchFirst(ThenAction, OnFirstErrorAction);
 
         // Assert
-        await action.Should().NotThrowAsync();
+        await Should.NotThrowAsync(action);
     }
 
     [Fact]
@@ -99,7 +98,7 @@ public class SwitchTests
     {
         // Arrange
         ErrorOr<Person> errorOrPerson = new Person("Dmitry");
-        void ThenAction(Person person) => person.Should().BeEquivalentTo(errorOrPerson.Value);
+        void ThenAction(Person person) => person.ShouldBe(errorOrPerson.Value);
         void ElsesAction(IReadOnlyList<Error> _) => throw new Exception("Should not be called");
 
         // Act
@@ -108,6 +107,6 @@ public class SwitchTests
             .Switch(ThenAction, ElsesAction);
 
         // Assert
-        await action.Should().NotThrowAsync();
+        await Should.NotThrowAsync(action);
     }
 }

--- a/tests/ErrorOr/ErrorOr.ThenAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.ThenAsyncTests.cs
@@ -1,6 +1,3 @@
-using ErrorOr;
-using FluentAssertions;
-
 namespace Tests;
 
 public class ThenAsyncTests
@@ -19,8 +16,8 @@ public class ThenAsyncTests
             .ThenAsync(Convert.ToStringAsync);
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().BeEquivalentTo("10");
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe("10");
     }
 
     [Fact]
@@ -37,7 +34,7 @@ public class ThenAsyncTests
             .ThenAsync(Convert.ToStringAsync);
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Should().BeEquivalentTo(errorOrString.FirstError);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.ShouldBe(errorOrString.FirstError);
     }
 }

--- a/tests/ErrorOr/ErrorOr.ThenTests.cs
+++ b/tests/ErrorOr/ErrorOr.ThenTests.cs
@@ -1,6 +1,3 @@
-using ErrorOr;
-using FluentAssertions;
-
 namespace Tests;
 
 public class ThenTests
@@ -18,8 +15,8 @@ public class ThenTests
             .Then(Convert.ToString);
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().BeEquivalentTo("10");
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe("10");
     }
 
     [Fact]
@@ -35,8 +32,8 @@ public class ThenTests
             .ThenDo(str => { _ = 5; });
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().Be(5);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(5);
     }
 
     [Fact]
@@ -53,8 +50,8 @@ public class ThenTests
             .Then(Convert.ToString);
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Should().BeEquivalentTo(errorOrString.FirstError);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.ShouldBe(errorOrString.FirstError);
     }
 
     [Fact]
@@ -73,8 +70,8 @@ public class ThenTests
             .ThenDo(num => { _ = 5; });
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().Be("10");
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe("10");
     }
 
     [Fact]
@@ -89,7 +86,7 @@ public class ThenTests
             .Then(Convert.ToString);
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Should().BeEquivalentTo(errorOrString.FirstError);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.ShouldBe(errorOrString.FirstError);
     }
 }

--- a/tests/ErrorOr/ErrorOr.ToErrorOrTests.cs
+++ b/tests/ErrorOr/ErrorOr.ToErrorOrTests.cs
@@ -1,6 +1,3 @@
-using ErrorOr;
-using FluentAssertions;
-
 namespace Tests;
 
 public class ToErrorOrTests
@@ -15,8 +12,8 @@ public class ToErrorOrTests
         ErrorOr<int> result = value.ToErrorOr();
 
         // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.Should().Be(value);
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe(value);
     }
 
     [Fact]
@@ -29,8 +26,8 @@ public class ToErrorOrTests
         ErrorOr<int> result = error.ToErrorOr<int>();
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.FirstError.Should().Be(error);
+        result.IsError.ShouldBeTrue();
+        result.FirstError.ShouldBe(error);
     }
 
     [Fact]
@@ -43,8 +40,8 @@ public class ToErrorOrTests
         ErrorOr<int> result = errors.ToErrorOr<int>();
 
         // Assert
-        result.IsError.Should().BeTrue();
-        result.Errors.Should().BeEquivalentTo(errors);
+        result.IsError.ShouldBeTrue();
+        result.Errors.ShouldBe(errors);
     }
 
     [Fact]
@@ -54,7 +51,7 @@ public class ToErrorOrTests
 
         ErrorOr<int> result = errors.ToErrorOr<int>();
 
-        result.IsError.Should().BeTrue();
-        result.Errors.Should().Equal(errors);
+        result.IsError.ShouldBeTrue();
+        result.Errors.ShouldBe(errors);
     }
 }

--- a/tests/ErrorOr/TestUtils.cs
+++ b/tests/ErrorOr/TestUtils.cs
@@ -1,5 +1,3 @@
-using ErrorOr;
-
 namespace Tests;
 
 public static class Convert

--- a/tests/ErrorOr/TestUtils.cs
+++ b/tests/ErrorOr/TestUtils.cs
@@ -6,7 +6,7 @@ public static class Convert
 
     public static ErrorOr<int> ToInt(string str) => int.Parse(str);
 
-    public static Task<ErrorOr<int>> ToIntAsync(string str) => Task.FromResult(ErrorOrFactory.From(int.Parse(str)));
+    public static Task<ErrorOr<int>> ToIntAsync(string str) => Task.FromResult(ErrorOrFactory.Create(int.Parse(str)));
 
-    public static Task<ErrorOr<string>> ToStringAsync(int num) => Task.FromResult(ErrorOrFactory.From(num.ToString()));
+    public static Task<ErrorOr<string>> ToStringAsync(int num) => Task.FromResult(ErrorOrFactory.Create(num.ToString()));
 }

--- a/tests/Errors/Error.EqualityTests.cs
+++ b/tests/Errors/Error.EqualityTests.cs
@@ -1,19 +1,16 @@
-﻿using ErrorOr;
-using FluentAssertions;
-
 namespace Tests;
 
 public sealed class ErrorEqualityTests
 {
     public static readonly TheoryData<string, string, int, Dictionary<string, object>?> ValidData =
-        new ()
+        new()
         {
             { "CodeA", "DescriptionA", 1, null },
             { "CodeB", "DescriptionB", 3215, new Dictionary<string, object> { { "foo", "bar" }, { "baz", "qux" } } },
         };
 
     public static readonly TheoryData<Error, Error> DifferentInstances =
-        new ()
+        new()
         {
             { Error.Failure(), Error.Forbidden() },
             { Error.NotFound(), Error.NotFound(metadata: new Dictionary<string, object> { ["Foo"] = "Bar" }) },
@@ -42,7 +39,7 @@ public sealed class ErrorEqualityTests
 
         var result = error1.Equals(error2);
 
-        result.Should().BeTrue();
+        result.ShouldBeTrue();
     }
 
     [Fact]
@@ -54,7 +51,7 @@ public sealed class ErrorEqualityTests
 
         var result = error1.Equals(error2);
 
-        result.Should().BeTrue();
+        result.ShouldBeTrue();
     }
 
     [Theory]
@@ -63,7 +60,7 @@ public sealed class ErrorEqualityTests
     {
         var result = error1.Equals(error2);
 
-        result.Should().BeFalse();
+        result.ShouldBeFalse();
     }
 
     [Theory]
@@ -81,7 +78,7 @@ public sealed class ErrorEqualityTests
         var hashCode1 = error1.GetHashCode();
         var hashCode2 = error2.GetHashCode();
 
-        hashCode1.Should().Be(hashCode2);
+        hashCode1.ShouldBe(hashCode2);
     }
 
     [Theory]
@@ -93,6 +90,6 @@ public sealed class ErrorEqualityTests
         var hashCode1 = error1.GetHashCode();
         var hashCode2 = error2.GetHashCode();
 
-        hashCode1.Should().NotBe(hashCode2);
+        hashCode1.ShouldNotBe(hashCode2);
     }
 }

--- a/tests/Errors/ErrorTests.cs
+++ b/tests/Errors/ErrorTests.cs
@@ -1,6 +1,3 @@
-using ErrorOr;
-using FluentAssertions;
-
 namespace Tests;
 
 public class ErrorTests
@@ -95,10 +92,10 @@ public class ErrorTests
 
     private static void ValidateError(Error error, ErrorType expectedErrorType)
     {
-        error.Code.Should().Be(ErrorCode);
-        error.Description.Should().Be(ErrorDescription);
-        error.Type.Should().Be(expectedErrorType);
-        error.NumericType.Should().Be((int)expectedErrorType);
-        error.Metadata.Should().BeEquivalentTo(Dictionary);
+        error.Code.ShouldBe(ErrorCode);
+        error.Description.ShouldBe(ErrorDescription);
+        error.Type.ShouldBe(expectedErrorType);
+        error.NumericType.ShouldBe((int)expectedErrorType);
+        error.Metadata.ShouldBe(Dictionary);
     }
 }

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+  
+  <PropertyGroup>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -1,17 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="fluentassertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.8.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Usings.cs
+++ b/tests/Usings.cs
@@ -1,1 +1,3 @@
+global using ErrorOr;
+global using Shouldly;
 global using Xunit;


### PR DESCRIPTION
This pull request introduces major updates for version 3.0.0 of the library, focusing on multi-targeting newer .NET versions, significant internal refactoring for error handling, and repository rebranding. The most important changes are grouped below:

**Platform and CI Upgrades**
* The project now multi-targets `net8.0`, `net9.0`, and `net10.0`, ensuring compatibility with the latest .NET releases. CI workflows (`build.yml`, `publish.yml`) have been updated to use .NET 10.0.x. (`[[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R27)`, `[[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L19-R19)`, `[[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L18-R18)`, `[[4]](diffhunk://#diff-450094b5119f95003f05626bc3f7986f27f07051041f2ea9b58c6626c5082335R2-R28)`)
* Solution file format was modernized: removed legacy `ErrorOr.sln`, added new `ErrorOr.slnx` for improved IDE support. (`[[1]](diffhunk://#diff-1d23e4d49e3f2c70b68b76b25c410771425810bb02e6184c631aa33103716dddL1-L28)`, `[[2]](diffhunk://#diff-7b166fcd7ac5e5ec036f70972c66e699d4e0ccfd78aa6092c416bfa8dd18f5ebR1-R14)`)

**Error Handling Refactor (Breaking Changes)**
* Internals of `ErrorOr<TValue>` now use `ImmutableArray<Error>` instead of `List<Error>` for better immutability and performance. All public APIs now accept/return `ImmutableArray<Error>`, and related extension methods were updated. (`[[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R27)`, `[[2]](diffhunk://#diff-75ba63f387e1ee0d8ff2e14e51c9eeb37d34b1589988b631b592d39898fa99fbR1-R2)`, `[[3]](diffhunk://#diff-75ba63f387e1ee0d8ff2e14e51c9eeb37d34b1589988b631b592d39898fa99fbL10-R12)`, `[[4]](diffhunk://#diff-75ba63f387e1ee0d8ff2e14e51c9eeb37d34b1589988b631b592d39898fa99fbL25-R34)`, `[[5]](diffhunk://#diff-75ba63f387e1ee0d8ff2e14e51c9eeb37d34b1589988b631b592d39898fa99fbL55-R57)`, `[[6]](diffhunk://#diff-75ba63f387e1ee0d8ff2e14e51c9eeb37d34b1589988b631b592d39898fa99fbL85-R87)`, `[[7]](diffhunk://#diff-75ba63f387e1ee0d8ff2e14e51c9eeb37d34b1589988b631b592d39898fa99fbL100-R102)`, `[[8]](diffhunk://#diff-75ba63f387e1ee0d8ff2e14e51c9eeb37d34b1589988b631b592d39898fa99fbL115-R124)`, `[[9]](diffhunk://#diff-3e22ef306228878e6904cb187b4129c65a2e2f2fed7a135a73b5c4ffb533d8a9R1-R2)`)
* Public constructors of `ErrorOr<TValue>` are now `internal`; use factory methods or conversions for instantiation. (`[CHANGELOG.mdR5-R27](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R27)`)
* `FirstError` now returns `Error?` (nullable) for successful results, and the `Errors` collection is empty for success (no more sentinel value). (`[CHANGELOG.mdR5-R27](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R27)`)

**Repository Rebranding and Documentation**
* Updated all references, badges, and metadata to the new repository owner (`dzhukovsky`) and package name (`dzhukovsky.ErrorOr`). README and LICENSE were revised accordingly. (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R16)`, `[[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37)`, `[[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L228)`, `[[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R330-R331)`, `[[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R344-R345)`, `[[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L353-L366)`, `[[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L395)`, `[[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R613)`, `[[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R751-R756)`, `[[10]](diffhunk://#diff-450094b5119f95003f05626bc3f7986f27f07051041f2ea9b58c6626c5082335R2-R28)`, `[[11]](diffhunk://#diff-4673a3aba01813b595de187a7a6e9e63a3491d55821606fecd9f13a10c188a1dL3-R3)`)
* Added credits to the original `amantinband/error-or` repository in the documentation. (`[README.mdR751-R756](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R751-R756)`)

**Codebase Cleanup**
* Removed obsolete files and code, including the unused `EmptyErrors.cs` helper. (`[src/ErrorOr/EmptyErrors.csL1-L6](diffhunk://#diff-3208bbcca820a3872376fee24ce89c6554d301e1b30d91a021db54c6e2037a4bL1-L6)`)
* Minor cleanups and normalization in project and props files. (`[[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL1-R6)`, `[[2]](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bL5-R12)`)

These changes include several breaking changes, so downstream code may require updates to work with the new error collection types and APIs.