### PR TITLE
BREAKING CHANGE: Refactor Error/Or: metadata equality, API, and safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project are documented in this file.
 
+## [4.0.0] - 2025-12-10
+
+### Breaking Changes
+
+- Removed the `NumericType` property from `Error`; consumers should rely on `ErrorType` directly.
+- `ErrorOr<T>` now throws when constructed with a default or empty `ImmutableArray<Error>`, enforcing that error collections are always non-empty for failure cases.
+
+### Changed
+
+- Refactored `Error` equality and hash code implementations to use `DictionaryEqualityComparer` for `Metadata` comparison and hashing.
+- Added `Error.IsDefault` to distinguish uninitialized error instances from valid errors.
+- Normalized `Error.Metadata` to always be exposed as a read-only dictionary, improving safety and consistency of metadata usage.
+- Improved `IErrorOr` XML documentation and interface contracts for clearer behavior and usage guidance.
+
+### Added
+
+- Introduced `DictionaryEqualityComparer` to provide value-based equality and hash code support for dictionaries.
+- Added comprehensive unit tests for `DictionaryEqualityComparer` covering key/value equality and hash code behavior.
+- Expanded tests for `ErrorOr<T>` instantiation, `ToErrorOr` conversions, and error array handling to validate the new contracts.
+
 ## [3.0.0] - 2025-12-04
 
 ### Added
@@ -22,19 +42,6 @@ All notable changes to this project are documented in this file.
 - All APIs that previously accepted or returned `List<Error>` now use `ImmutableArray<Error>`. Call sites relying on the previous collection types may require adjustments.
 - Public constructors of `ErrorOr<TValue>` were made `internal`. Creating instances should now be done via `ErrorOrFactory`, `ToErrorOr`, or implicit conversions.
 - For successful results, the `Errors` collection no longer contains a special "no error" sentinel item. It is now an empty collection. Code that relied on this sentinel (for example, by assuming `Errors` is always non-empty and contains a "no error" value for success) must be updated to treat an empty `Errors` as the indicator of success.
-
-## [1.10.0] - 2024-02-14
-
-### Added
-
-- `ErrorType.Forbidden`
-- README to NuGet package
-
-## [1.9.0] - 2024-01-06
-
-### Added
-
-- `ToErrorOr`
 
 ## [2.0.0] - 2024-03-26
 
@@ -76,3 +83,16 @@ errorOr.FailIf(x => x > 0, Error.Failure());
 -public static async Task<ErrorOr<TValue>> ThenAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
 +public static async Task<ErrorOr<TValue>> ThenDoAsync<TValue>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task> action)
 ```
+
+## [1.10.0] - 2024-02-14
+
+### Added
+
+- `ErrorType.Forbidden`
+- README to NuGet package
+
+## [1.9.0] - 2024-01-06
+
+### Added
+
+- `ToErrorOr`

--- a/src/Comparers/DictionaryEqualityComparer.cs
+++ b/src/Comparers/DictionaryEqualityComparer.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 
-namespace ErrorOr.Comparers;
+namespace ErrorOr;
 
 /// <summary>
 /// Provides an equality comparer for <see cref="IReadOnlyDictionary{TKey, TValue}"/> instances

--- a/src/Comparers/DictionaryEqualityComparer.cs
+++ b/src/Comparers/DictionaryEqualityComparer.cs
@@ -1,0 +1,72 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace ErrorOr.Comparers;
+
+/// <summary>
+/// Provides an equality comparer for <see cref="IReadOnlyDictionary{TKey, TValue}"/> instances
+/// that compares dictionaries by their key-value pairs in an order-independent manner.
+/// </summary>
+/// <typeparam name="TKey">The type of keys in the dictionary.</typeparam>
+/// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
+/// <param name="valueComparer">
+/// An optional equality comparer for values. If <c>null</c>, <see cref="EqualityComparer{T}.Default"/> is used.
+/// </param>
+/// <remarks>
+/// Two dictionaries are considered equal if they have the same count and contain the same key-value pairs,
+/// regardless of the order in which the pairs are enumerated.
+/// </remarks>
+internal sealed class DictionaryEqualityComparer<TKey, TValue>(
+    IEqualityComparer<TValue>? valueComparer = null)
+    : IEqualityComparer<IReadOnlyDictionary<TKey, TValue>>
+    where TKey : notnull
+{
+    private readonly IEqualityComparer<TValue> _valueComparer = valueComparer ?? EqualityComparer<TValue>.Default;
+
+    /// <summary>
+    /// Gets the default instance of <see cref="DictionaryEqualityComparer{TKey, TValue}"/>
+    /// using the default equality comparers for keys and values.
+    /// </summary>
+    public static DictionaryEqualityComparer<TKey, TValue> Default { get; } = new();
+
+    /// <inheritdoc />
+    public bool Equals(IReadOnlyDictionary<TKey, TValue>? x, IReadOnlyDictionary<TKey, TValue>? y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
+        if (x is null || y is null || x.Count != y.Count)
+        {
+            return false;
+        }
+
+        foreach (var pair in x)
+        {
+            if (!y.TryGetValue(pair.Key, out var otherValue) ||
+                !_valueComparer.Equals(pair.Value, otherValue))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public int GetHashCode([DisallowNull] IReadOnlyDictionary<TKey, TValue> obj)
+    {
+        var keysHash = 0;
+        var valuesHash = 0;
+
+        foreach (var pair in obj)
+        {
+            keysHash ^= pair.Key.GetHashCode();
+            valuesHash ^= pair.Value is null
+                ? 0
+                : _valueComparer.GetHashCode(pair.Value);
+        }
+
+        return HashCode.Combine(obj.Count, keysHash, valuesHash);
+    }
+}

--- a/src/ErrorOr.csproj
+++ b/src/ErrorOr.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>dzhukovsky.ErrorOr</PackageId>
-    <Version>3.0.0</Version>
+    <Version>4.0.0</Version>
     <Authors>Dmitry Zhukovsky</Authors>
     <PackageIcon>icon-square.png</PackageIcon>
     <PackageTags>Result,Results,ErrorOr,Error,Handling</PackageTags>
@@ -18,6 +18,10 @@
     <PackageOutputPath>../artifacts/</PackageOutputPath>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Tests" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Include="../assets/icon-square.png" Pack="true" Visible="false" PackagePath="" />

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -18,7 +18,7 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     /// <exception cref="ArgumentException">List is empty.</exception>
     internal ErrorOr(ImmutableArray<Error> errors)
     {
-        if (errors.Length == 0)
+        if (errors.IsDefault || errors.Length == 0)
         {
             throw new ArgumentException($"Cannot create an ErrorOr<> from an empty collection of errors. Provide at least one error.", nameof(errors));
         }
@@ -35,16 +35,16 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
         Errors = [];
     }
 
-    /// <summary>Gets the errors when in the error state; empty when successful.</summary>
+    /// <inheritdoc/>
     public ImmutableArray<Error> Errors { get; }
 
     /// <summary>Gets the first error or the default value.</summary>
     public Error FirstError => IsError ? Errors[0] : default;
 
-    /// <summary>Gets a value indicating whether the result contains errors.</summary>
+    /// <inheritdoc/>
     [MemberNotNullWhen(false, nameof(Value))]
     public bool IsError => Errors.Length > 0;
 
-    /// <summary>Gets the value when successful; <c>null</c> when error.</summary>
+    /// <inheritdoc/>
     public TValue? Value { get; }
 }

--- a/src/ErrorOr/IErrorOr.cs
+++ b/src/ErrorOr/IErrorOr.cs
@@ -4,27 +4,17 @@ namespace ErrorOr;
 
 public interface IErrorOr<out TValue> : IErrorOr
 {
-    /// <summary>
-    /// Gets the value.
-    /// </summary>
+    /// <summary>Gets the value when successful; <c>null</c> when error.</summary>
     TValue? Value { get; }
 }
 
-/// <summary>
-/// Type-less interface for the <see cref="ErrorOr"/> object.
-/// </summary>
-/// <remarks>
-/// This interface is intended for use when the underlying type of the <see cref="ErrorOr"/> object is unknown.
-/// </remarks>
+/// <summary>Type-less interface for the <see cref="ErrorOr"/> object.</summary>
+/// <remarks>This interface is intended for use when the underlying type of the <see cref="ErrorOr"/> object is unknown.</remarks>
 public interface IErrorOr
 {
-    /// <summary>
-    /// Gets the collection of errors.
-    /// </summary>
+    /// <summary>Gets the errors when in the error state; empty when successful.</summary>
     ImmutableArray<Error> Errors { get; }
 
-    /// <summary>
-    /// Gets a value indicating whether the state is error.
-    /// </summary>
+    /// <summary>Gets a value indicating whether the result contains errors.</summary>
     bool IsError { get; }
 }

--- a/src/Errors/Error.cs
+++ b/src/Errors/Error.cs
@@ -1,5 +1,4 @@
 using System.Collections.ObjectModel;
-using ErrorOr.Comparers;
 
 namespace ErrorOr;
 

--- a/tests/Comparers/DictionaryEqualityComparerTests.cs
+++ b/tests/Comparers/DictionaryEqualityComparerTests.cs
@@ -96,7 +96,7 @@ public class DictionaryEqualityComparerTests
     }
 
     [Fact]
-    public void Equals_UsesCustomKeyComparer_ReturnsFalse()
+    public void Equals_DifferentCasingKeys_ReturnsFalse()
     {
         IReadOnlyDictionary<string, int> x = new Dictionary<string, int> { ["a"] = 1 };
         IReadOnlyDictionary<string, int> y = new Dictionary<string, int> { ["A"] = 1 };

--- a/tests/Comparers/DictionaryEqualityComparerTests.cs
+++ b/tests/Comparers/DictionaryEqualityComparerTests.cs
@@ -1,0 +1,196 @@
+using ErrorOr.Comparers;
+
+namespace ErrorOr.Tests.Comparers;
+
+public class DictionaryEqualityComparerTests
+{
+    [Fact]
+    public void Equals_SameReference_ReturnsTrue()
+    {
+        var dict = new Dictionary<string, int> { ["a"] = 1 };
+        var comparer = DictionaryEqualityComparer<string, int>.Default;
+
+        var result = comparer.Equals(dict, dict);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_BothNull_ReturnsTrue()
+    {
+        IReadOnlyDictionary<string, int>? x = null;
+        IReadOnlyDictionary<string, int>? y = null;
+        var comparer = DictionaryEqualityComparer<string, int>.Default;
+
+        var result = comparer.Equals(x, y);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_OneNull_ReturnsFalse()
+    {
+        IReadOnlyDictionary<string, int>? x = null;
+        IReadOnlyDictionary<string, int>? y = new Dictionary<string, int>();
+        var comparer = DictionaryEqualityComparer<string, int>.Default;
+
+        var result = comparer.Equals(x, y);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_DifferentCount_ReturnsFalse()
+    {
+        var x = new Dictionary<string, int> { ["a"] = 1 };
+        var y = new Dictionary<string, int>();
+        var comparer = DictionaryEqualityComparer<string, int>.Default;
+
+        var result = comparer.Equals(x, y);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_SamePairsDifferentOrder_ReturnsTrue()
+    {
+        IReadOnlyDictionary<string, int> x = new Dictionary<string, int>
+        {
+            ["a"] = 1,
+            ["b"] = 2,
+        };
+
+        IReadOnlyDictionary<string, int> y = new Dictionary<string, int>
+        {
+            ["b"] = 2,
+            ["a"] = 1,
+        };
+
+        var comparer = DictionaryEqualityComparer<string, int>.Default;
+
+        var result = comparer.Equals(x, y);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_DifferentValuesForSameKey_ReturnsFalse()
+    {
+        IReadOnlyDictionary<string, int> x = new Dictionary<string, int> { ["a"] = 1 };
+        IReadOnlyDictionary<string, int> y = new Dictionary<string, int> { ["a"] = 2 };
+        var comparer = DictionaryEqualityComparer<string, int>.Default;
+
+        var result = comparer.Equals(x, y);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_DifferentKeys_ReturnsFalse()
+    {
+        IReadOnlyDictionary<string, int> x = new Dictionary<string, int> { ["a"] = 1 };
+        IReadOnlyDictionary<string, int> y = new Dictionary<string, int> { ["b"] = 1 };
+        var comparer = DictionaryEqualityComparer<string, int>.Default;
+
+        var result = comparer.Equals(x, y);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_UsesCustomKeyComparer_ReturnsFalse()
+    {
+        IReadOnlyDictionary<string, int> x = new Dictionary<string, int> { ["a"] = 1 };
+        IReadOnlyDictionary<string, int> y = new Dictionary<string, int> { ["A"] = 1 };
+        var comparer = new DictionaryEqualityComparer<string, int>();
+
+        var result = comparer.Equals(x, y);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_UsesCustomValueComparer()
+    {
+        IReadOnlyDictionary<string, string> x = new Dictionary<string, string> { ["a"] = "value" };
+        IReadOnlyDictionary<string, string> y = new Dictionary<string, string> { ["a"] = "VALUE" };
+        var comparer = new DictionaryEqualityComparer<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        var result = comparer.Equals(x, y);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetHashCode_EqualDictionariesSameOrder_ProducesSameHashCode()
+    {
+        IReadOnlyDictionary<string, int> x = new Dictionary<string, int>
+        {
+            ["a"] = 1,
+            ["b"] = 2,
+        };
+
+        IReadOnlyDictionary<string, int> y = new Dictionary<string, int>
+        {
+            ["a"] = 1,
+            ["b"] = 2,
+        };
+
+        var comparer = DictionaryEqualityComparer<string, int>.Default;
+
+        var hashX = comparer.GetHashCode(x);
+        var hashY = comparer.GetHashCode(y);
+
+        hashX.ShouldBe(hashY);
+    }
+
+    [Fact]
+    public void GetHashCode_EqualDictionariesDifferentOrder_ProducesSameHashCode()
+    {
+        IReadOnlyDictionary<string, int> x = new Dictionary<string, int>
+        {
+            ["a"] = 1,
+            ["b"] = 2,
+        };
+
+        IReadOnlyDictionary<string, int> y = new Dictionary<string, int>
+        {
+            ["b"] = 2,
+            ["a"] = 1,
+        };
+
+        var comparer = DictionaryEqualityComparer<string, int>.Default;
+
+        var hashX = comparer.GetHashCode(x);
+        var hashY = comparer.GetHashCode(y);
+
+        hashX.ShouldBe(hashY);
+    }
+
+    [Fact]
+    public void GetHashCode_DifferentDictionaries_ProducesDifferentHashCodes()
+    {
+        IReadOnlyDictionary<string, int> x = new Dictionary<string, int> { ["a"] = 1 };
+        IReadOnlyDictionary<string, int> y = new Dictionary<string, int> { ["a"] = 2 };
+        var comparer = DictionaryEqualityComparer<string, int>.Default;
+
+        var hashX = comparer.GetHashCode(x);
+        var hashY = comparer.GetHashCode(y);
+
+        hashX.ShouldNotBe(hashY);
+    }
+
+    [Fact]
+    public void GetHashCode_HandlesNullValues()
+    {
+        IReadOnlyDictionary<string, string?> dict = new Dictionary<string, string?>
+        {
+            ["a"] = null,
+            ["b"] = "value",
+        };
+
+        var comparer = new DictionaryEqualityComparer<string, string?>();
+
+        Should.NotThrow(() => comparer.GetHashCode(dict));
+    }
+}

--- a/tests/Comparers/DictionaryEqualityComparerTests.cs
+++ b/tests/Comparers/DictionaryEqualityComparerTests.cs
@@ -1,6 +1,4 @@
-using ErrorOr.Comparers;
-
-namespace ErrorOr.Tests.Comparers;
+namespace Tests;
 
 public class DictionaryEqualityComparerTests
 {

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Tests;
 
 public class ErrorOrInstantiationTests
@@ -11,7 +13,7 @@ public class ErrorOrInstantiationTests
         IEnumerable<string> value = ["value"];
 
         // Act
-        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.Create(value);
+        var errorOrPerson = ErrorOrFactory.Create(value);
 
         // Assert
         errorOrPerson.IsError.ShouldBeFalse();
@@ -23,7 +25,7 @@ public class ErrorOrInstantiationTests
     {
         // Arrange
         IEnumerable<string> value = ["value"];
-        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.Create(value);
+        var errorOrPerson = ErrorOrFactory.Create(value);
 
         // Act & Assert
         errorOrPerson.FirstError.ShouldBe(default);
@@ -34,7 +36,7 @@ public class ErrorOrInstantiationTests
     {
         // Arrange
         IEnumerable<string> value = ["value"];
-        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.Create(value);
+        var errorOrPerson = ErrorOrFactory.Create(value);
 
         // Act & Assert
         errorOrPerson.Errors.ShouldBeEmpty();
@@ -47,7 +49,7 @@ public class ErrorOrInstantiationTests
         IEnumerable<string> value = ["value"];
 
         // Act
-        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.Create(value);
+        var errorOrPerson = ErrorOrFactory.Create(value);
 
         // Assert
         errorOrPerson.IsError.ShouldBeFalse();
@@ -59,7 +61,7 @@ public class ErrorOrInstantiationTests
     {
         // Arrange
         IEnumerable<string> value = ["value"];
-        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.Create(value);
+        var errorOrPerson = ErrorOrFactory.Create(value);
 
         // Act & Assert
         errorOrPerson.FirstError.ShouldBe(default);
@@ -70,7 +72,7 @@ public class ErrorOrInstantiationTests
     {
         // Arrange
         IEnumerable<string> value = ["value"];
-        ErrorOr<IEnumerable<string>> errorOrPerson = ErrorOrFactory.Create(value);
+        var errorOrPerson = ErrorOrFactory.Create(value);
 
         // Act & Assert
         errorOrPerson.Errors.ShouldBeEmpty();
@@ -81,7 +83,7 @@ public class ErrorOrInstantiationTests
     {
         // Arrange
         List<Error> errors = [Error.Validation("User.Name", "Name is too short")];
-        ErrorOr<Person> errorOrPerson = ErrorOrFactory.Create<Person>(errors);
+        var errorOrPerson = ErrorOrFactory.Create<Person>(errors);
 
         // Act & Assert
         errorOrPerson.IsError.ShouldBeTrue();
@@ -93,7 +95,7 @@ public class ErrorOrInstantiationTests
     {
         // Arrange
         List<Error> errors = [Error.Validation("User.Name", "Name is too short")];
-        ErrorOr<Person> errorOrPerson = ErrorOrFactory.Create<Person>(errors);
+        var errorOrPerson = ErrorOrFactory.Create<Person>(errors);
 
         // Act & Assert
         errorOrPerson.Value.ShouldBeNull();
@@ -281,6 +283,43 @@ public class ErrorOrInstantiationTests
     }
 
     [Fact]
+    public void ImplicitCastImmutableArrayOfErrors_WhenAccessingErrors_ShouldReturnErrors()
+    {
+        // Arrange
+        ImmutableArray<Error> errors =
+        [
+            Error.Validation("User.Name", "Name is too short"),
+            Error.Validation("User.Age", "User is too young"),
+        ];
+
+        // Act
+        ErrorOr<Person> errorOrPerson = errors;
+
+        // Assert
+        errorOrPerson.IsError.ShouldBeTrue();
+        errorOrPerson.Errors.Length.ShouldBe(errors.Length);
+        errorOrPerson.Errors.ShouldBe(errors);
+    }
+
+    [Fact]
+    public void ImplicitCastImmutableArrayOfErrors_WhenAccessingFirstError_ShouldReturnFirstError()
+    {
+        // Arrange
+        ImmutableArray<Error> errors =
+        [
+            Error.Validation("User.Name", "Name is too short"),
+            Error.Validation("User.Age", "User is too young"),
+        ];
+
+        // Act
+        ErrorOr<Person> errorOrPerson = errors;
+
+        // Assert
+        errorOrPerson.IsError.ShouldBeTrue();
+        errorOrPerson.FirstError.ShouldBe(errors[0]);
+    }
+
+    [Fact]
     public void CreateErrorOr_WhenUsingEmptyConstructor_ShouldThrow()
     {
         // Act & Assert
@@ -316,6 +355,30 @@ public class ErrorOrInstantiationTests
     public void CreateErrorOr_WhenNullIsPassedAsErrorsArray_ShouldThrowArgumentNullException()
     {
         var exception = Should.Throw<ArgumentNullException>(() => { ErrorOr<int> errorOr = default(Error[])!; });
+        exception.ParamName.ShouldBe("errors");
+    }
+
+    [Fact]
+    public void CreateErrorOr_WhenEmptyImmutableArrayIsUsed_ShouldThrow()
+    {
+        // Arrange
+        ImmutableArray<Error> errors = [];
+
+        // Act & Assert
+        var exception = Should.Throw<ArgumentException>(() => { ErrorOr<int> errorOr = errors; });
+        exception.Message.ShouldContain("Cannot create an ErrorOr<> from an empty collection of errors. Provide at least one error.");
+        exception.ParamName.ShouldBe("errors");
+    }
+
+    [Fact]
+    public void CreateErrorOr_WhenDefaultImmutableArrayIsUsed_ShouldThrow()
+    {
+        // Arrange
+        ImmutableArray<Error> errors = default;
+
+        // Act & Assert
+        var exception = Should.Throw<ArgumentException>(() => { ErrorOr<int> errorOr = errors; });
+        exception.Message.ShouldContain("Cannot create an ErrorOr<> from an empty collection of errors. Provide at least one error.");
         exception.ParamName.ShouldBe("errors");
     }
 

--- a/tests/ErrorOr/ErrorOr.InstantiationTests.cs
+++ b/tests/ErrorOr/ErrorOr.InstantiationTests.cs
@@ -365,7 +365,7 @@ public class ErrorOrInstantiationTests
         ImmutableArray<Error> errors = [];
 
         // Act & Assert
-        var exception = Should.Throw<ArgumentException>(() => { ErrorOr<int> errorOr = errors; });
+        var exception = Should.Throw<ArgumentException>(() => (ErrorOr<int>)errors);
         exception.Message.ShouldContain("Cannot create an ErrorOr<> from an empty collection of errors. Provide at least one error.");
         exception.ParamName.ShouldBe("errors");
     }
@@ -377,7 +377,7 @@ public class ErrorOrInstantiationTests
         ImmutableArray<Error> errors = default;
 
         // Act & Assert
-        var exception = Should.Throw<ArgumentException>(() => { ErrorOr<int> errorOr = errors; });
+        var exception = Should.Throw<ArgumentException>(() => (ErrorOr<int>)errors);
         exception.Message.ShouldContain("Cannot create an ErrorOr<> from an empty collection of errors. Provide at least one error.");
         exception.ParamName.ShouldBe("errors");
     }
@@ -385,7 +385,7 @@ public class ErrorOrInstantiationTests
     [Fact]
     public void CreateErrorOr_WhenValueIsNull_ShouldThrowArgumentNullException()
     {
-        var exception = Should.Throw<ArgumentNullException>(() => { ErrorOr<int?> errorOr = default(int?); });
+        var exception = Should.Throw<ArgumentNullException>(() => (ErrorOr<int?>)default(int?));
         exception.ParamName.ShouldBe("value");
     }
 }

--- a/tests/ErrorOr/ErrorOr.ToErrorOrTests.cs
+++ b/tests/ErrorOr/ErrorOr.ToErrorOrTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Tests;
 
 public class ToErrorOrTests
@@ -51,6 +53,20 @@ public class ToErrorOrTests
 
         ErrorOr<int> result = errors.ToErrorOr<int>();
 
+        result.IsError.ShouldBeTrue();
+        result.Errors.ShouldBe(errors);
+    }
+
+    [Fact]
+    public void ImmutableArrayOfErrorsToErrorOr_WhenAccessingErrors_ShouldReturnSameErrors()
+    {
+        // Arrange
+        ImmutableArray<Error> errors = [Error.Unauthorized(), Error.Validation()];
+
+        // Act
+        ErrorOr<int> result = errors.ToErrorOr<int>();
+
+        // Assert
         result.IsError.ShouldBeTrue();
         result.Errors.ShouldBe(errors);
     }

--- a/tests/Errors/ErrorTests.cs
+++ b/tests/Errors/ErrorTests.cs
@@ -95,7 +95,6 @@ public class ErrorTests
         error.Code.ShouldBe(ErrorCode);
         error.Description.ShouldBe(ErrorDescription);
         error.Type.ShouldBe(expectedErrorType);
-        error.NumericType.ShouldBe((int)expectedErrorType);
         error.Metadata.ShouldBe(Dictionary);
     }
 }


### PR DESCRIPTION
This pull request introduces several breaking changes and improvements for the upcoming `4.0.0` release, focusing on error representation, equality, and contract enforcement. The most significant updates include the removal of the `NumericType` property from `Error`, stricter construction rules for `ErrorOr<T>`, improved equality and hashing for errors with metadata, and the addition of a new dictionary equality comparer with comprehensive tests. Documentation and test coverage have also been expanded.

**Breaking changes and error handling:**

* Removed the `NumericType` property from the `Error` type; consumers should use `ErrorType` directly. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R24) [[2]](diffhunk://#diff-9c026c989f4236a0ce9263a6a15daa7dcec788443414a263b00b2249e614532cR1-R39)
* `ErrorOr<T>` now throws when constructed with a default or empty `ImmutableArray<Error>`, ensuring error collections are always non-empty for failure cases. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R24) [[2]](diffhunk://#diff-94d3226e5c428fefa8597a0e0d6950398a8af0a9014c163c50dec89d85237b1eL21-R21)

**Equality, hashing, and metadata:**

* Refactored `Error` equality and hash code implementations to use the new `DictionaryEqualityComparer` for value-based comparison of `Metadata` dictionaries, and normalized `Error.Metadata` to always be a read-only dictionary. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R24) [[2]](diffhunk://#diff-9c026c989f4236a0ce9263a6a15daa7dcec788443414a263b00b2249e614532cR1-R39)
* Added `Error.IsDefault` to distinguish uninitialized error instances from valid errors. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R24) [[2]](diffhunk://#diff-9c026c989f4236a0ce9263a6a15daa7dcec788443414a263b00b2249e614532cR1-R39)

**New features and utilities:**

* Introduced `DictionaryEqualityComparer` in `ErrorOr.Comparers` for order-independent, value-based dictionary comparison and hashing. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R24) [[2]](diffhunk://#diff-927b75792ca68b5462e7e975dddb2f5be6353b2f73c010f3d522ca05ca33332bR1-R72)
* Added comprehensive unit tests for `DictionaryEqualityComparer`, covering equality scenarios and hash code behavior. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R24) [[2]](diffhunk://#diff-1c1c937a0fd132caf982dcf155d51dafbb21d6d913f76023548aa7a63e128060R1-R196)

**Documentation and interface improvements:**

* Improved XML documentation and interface contracts for `IErrorOr`, clarifying behavior and usage. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R24) [[2]](diffhunk://#diff-be439db133214691c5872822e1329ce209a1b6ccf84bb772bfbf0aea62621720L7-R18)
* Expanded tests for `ErrorOr<T>` instantiation and error handling to validate new contracts. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R24) [[2]](diffhunk://#diff-5b45a980f5a8fe0c746ee5bcda5bacd2d9fb1614cad9cb636ac5f5206fc1fbc9R1-R2)

**Other changes:**

* Updated project version to `4.0.0` and made internals visible to the test assembly. [[1]](diffhunk://#diff-450094b5119f95003f05626bc3f7986f27f07051041f2ea9b58c6626c5082335L9-R9) [[2]](diffhunk://#diff-450094b5119f95003f05626bc3f7986f27f07051041f2ea9b58c6626c5082335R22-R25)
* Cleaned up and reorganized the `CHANGELOG.md`, restoring missing release notes for earlier versions. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL26-L38) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR86-R98)